### PR TITLE
Update Minecraft Vanilla scrolls for new runtime

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,17 +30,16 @@ jobs:
       - name: Install druid
         run: |
           install .ci/druid-cli/bin/druid /usr/local/bin/druid
-          install .ci/druid-cli/bin/druid-client /usr/local/bin/druid-client
-      - name: Validate Minecraft Vanilla scrolls
+      - name: Validate all scrolls
         run: |
           set -euo pipefail
-          for dir in ./scrolls/minecraft/minecraft-vanilla/*; do
+          for dir in $(find ./scrolls -type f -name scroll.yaml -exec dirname {} \; | sort); do
             [ -f "$dir/scroll.yaml" ] || continue
-            druid validate "$dir"
+            druid validate --strict "$dir"
           done
       - name: Login to registry
         if: github.event.pull_request.head.repo.full_name == github.repository
-        run: druid-client login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
+        run: druid login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
       - name: Ensure experimental registry project
         if: github.event.pull_request.head.repo.full_name == github.repository
         shell: bash
@@ -68,14 +67,14 @@ jobs:
           for dir in ./scrolls/minecraft/minecraft-vanilla/*; do
             [ -f "$dir/scroll.yaml" ] || continue
             version="$(basename "$dir")"
-            druid-client push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:${version}-pr${pr_number}" "$dir" \
+            druid push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:${version}-pr${pr_number}" "$dir" \
               -p main=25565 -p rcon=25575 \
               -i artifacts.druid.gg/druid-team/druid:stable-nix \
               --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
               --smart --category minecraft
 
             if [ "$version" = "1.21.7" ]; then
-              druid-client push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:latest-pr${pr_number}" "$dir" \
+              druid push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:latest-pr${pr_number}" "$dir" \
                 -p main=25565 -p rcon=25575 \
                 -i artifacts.druid.gg/druid-team/druid:stable-nix \
                 --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,14 +17,68 @@ jobs:
           go-version: ">=1.19.3"
       - run: apt update && apt install -y make
       - run: make build-tree
-      - name: Get registry binary
-        uses: robinraju/release-downloader@v1.7
+      - name: Checkout druid-cli
+        uses: actions/checkout@v3
         with:
-          repository: "highcard-dev/druid-cli"
-          latest: true
-          fileName: "druid"
+          repository: highcard-dev/druid-cli
+          ref: feat/druid-k8s-runtime-owner
+          path: .ci/druid-cli
           token: ${{ secrets.GO_REPO_TOKEN }}
-      - run: chmod +x ./druid
+      - name: Build druid
+        working-directory: .ci/druid-cli
+        run: make build
       - name: Install druid
-        run: mv ./druid /usr/local/bin/druid
-      - run: ./scripts/validate_all_scrolls.sh
+        run: |
+          install .ci/druid-cli/bin/druid /usr/local/bin/druid
+          install .ci/druid-cli/bin/druid-client /usr/local/bin/druid-client
+      - name: Validate Minecraft Vanilla scrolls
+        run: |
+          set -euo pipefail
+          for dir in ./scrolls/minecraft/minecraft-vanilla/*; do
+            [ -f "$dir/scroll.yaml" ] || continue
+            druid validate "$dir"
+          done
+      - name: Login to registry
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: druid-client login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
+      - name: Ensure experimental registry project
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          registry_host="${{ secrets.SCROLL_REGISTRY_HOST }}"
+          registry_host="${registry_host#http://}"
+          registry_host="${registry_host#https://}"
+          registry_host="${registry_host%%/*}"
+          status="$(curl -sS -o /tmp/druid-project-create.json -w '%{http_code}' \
+            -u '${{ secrets.SCROLL_REGISTRY_USER }}:${{ secrets.SCROLL_REGISTRY_PASSWORD }}' \
+            -H 'Content-Type: application/json' \
+            -X POST "https://${registry_host}/api/v2.0/projects" \
+            --data '{"project_name":"druid-team-experimental","metadata":{"public":"false"},"storage_limit":-1}')"
+          case "$status" in
+            201|409) ;;
+            *) cat /tmp/druid-project-create.json; exit 1 ;;
+          esac
+      - name: Push experimental Minecraft Vanilla artifacts
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr_number="${{ github.event.pull_request.number }}"
+          for dir in ./scrolls/minecraft/minecraft-vanilla/*; do
+            [ -f "$dir/scroll.yaml" ] || continue
+            version="$(basename "$dir")"
+            druid-client push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:${version}-pr${pr_number}" "$dir" \
+              -p main=25565 -p rcon=25575 \
+              -i artifacts.druid.gg/druid-team/druid:stable-nix \
+              --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
+              --smart --category minecraft
+
+            if [ "$version" = "1.21.7" ]; then
+              druid-client push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:latest-pr${pr_number}" "$dir" \
+                -p main=25565 -p rcon=25575 \
+                -i artifacts.druid.gg/druid-team/druid:stable-nix \
+                --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
+                --smart --category minecraft
+            fi
+          done

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,13 +3,8 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  build-deploy:
+  validate:
     runs-on: self-hosted
-    env:
-      SCROLL_REGISTRY_ENDPOINT: ${{ secrets.SCROLL_REGISTRY_ENDPOINT }}
-      SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
-      SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
-      SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -17,70 +12,16 @@ jobs:
           go-version: ">=1.19.3"
       - run: apt update && apt install -y make
       - name: Build scroll tree
-        env:
-          DRUID_COLDSTARTER_IMAGE: artifacts.druid.gg/druid-team-experimental/druid:stable-pr${{ github.event.pull_request.number }}
         run: make build-tree
-      - name: Checkout druid-cli
-        uses: actions/checkout@v3
+      - name: Get druid binary
+        uses: robinraju/release-downloader@v1.7
         with:
-          repository: highcard-dev/druid-cli
-          ref: feat/druid-k8s-runtime-owner
-          path: .ci/druid-cli
+          repository: "highcard-dev/druid-cli"
+          latest: true
+          fileName: "druid"
           token: ${{ secrets.GO_REPO_TOKEN }}
-      - name: Build druid
-        working-directory: .ci/druid-cli
-        run: make build
+      - run: chmod +x ./druid
       - name: Install druid
-        run: |
-          install .ci/druid-cli/bin/druid /usr/local/bin/druid
+        run: mv ./druid /usr/local/bin/druid
       - name: Validate all scrolls
-        run: |
-          set -euo pipefail
-          for dir in $(find ./scrolls -type f -name scroll.yaml -exec dirname {} \; | sort); do
-            [ -f "$dir/scroll.yaml" ] || continue
-            druid validate --strict "$dir"
-          done
-      - name: Login to registry
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        run: druid login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
-      - name: Ensure experimental registry project
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          registry_host="${{ secrets.SCROLL_REGISTRY_HOST }}"
-          registry_host="${registry_host#http://}"
-          registry_host="${registry_host#https://}"
-          registry_host="${registry_host%%/*}"
-          status="$(curl -sS -o /tmp/druid-project-create.json -w '%{http_code}' \
-            -u '${{ secrets.SCROLL_REGISTRY_USER }}:${{ secrets.SCROLL_REGISTRY_PASSWORD }}' \
-            -H 'Content-Type: application/json' \
-            -X POST "https://${registry_host}/api/v2.0/projects" \
-            --data '{"project_name":"druid-team-experimental","metadata":{"public":"false"},"storage_limit":-1}')"
-          case "$status" in
-            201|409) ;;
-            *) cat /tmp/druid-project-create.json; exit 1 ;;
-          esac
-      - name: Push experimental Minecraft Vanilla artifacts
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        shell: bash
-        run: |
-          set -euo pipefail
-          pr_number="${{ github.event.pull_request.number }}"
-          for dir in ./scrolls/minecraft/minecraft-vanilla/*; do
-            [ -f "$dir/scroll.yaml" ] || continue
-            version="$(basename "$dir")"
-            druid push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:${version}-pr${pr_number}" "$dir" \
-              -p main=25565 -p rcon=25575 \
-              -i artifacts.druid.gg/druid-team/druid:stable-nix \
-              --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
-              --smart --category minecraft
-
-            if [ "$version" = "1.21.7" ]; then
-              druid push "artifacts.druid.gg/druid-team-experimental/scroll-minecraft-vanilla:latest-pr${pr_number}" "$dir" \
-                -p main=25565 -p rcon=25575 \
-                -i artifacts.druid.gg/druid-team/druid:stable-nix \
-                --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
-                --smart --category minecraft
-            fi
-          done
+        run: ./scripts/validate_all_scrolls.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,10 @@ jobs:
         with:
           go-version: ">=1.19.3"
       - run: apt update && apt install -y make
-      - run: make build-tree
+      - name: Build scroll tree
+        env:
+          DRUID_COLDSTARTER_IMAGE: artifacts.druid.gg/druid-team-experimental/druid:stable-pr${{ github.event.pull_request.number }}
+        run: make build-tree
       - name: Checkout druid-cli
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,15 +13,5 @@ jobs:
       - run: apt update && apt install -y make
       - name: Build scroll tree
         run: make build-tree
-      - name: Get druid binary
-        uses: robinraju/release-downloader@v1.7
-        with:
-          repository: "highcard-dev/druid-cli"
-          latest: true
-          fileName: "druid"
-          token: ${{ secrets.GO_REPO_TOKEN }}
-      - run: chmod +x ./druid
-      - name: Install druid
-        run: mv ./druid /usr/local/bin/druid
       - name: Validate all scrolls
         run: ./scripts/validate_all_scrolls.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,8 +3,14 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  validate:
+  build-deploy:
     runs-on: self-hosted
+    env:
+      SCROLL_REGISTRY_PR_NAMESPACE: druid-team-experimental
+      SCROLL_REGISTRY_ENDPOINT: ${{ secrets.SCROLL_REGISTRY_ENDPOINT }}
+      SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
+      SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
+      SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -12,6 +18,35 @@ jobs:
           go-version: ">=1.19.3"
       - run: apt update && apt install -y make
       - name: Build scroll tree
-        run: make build-tree
+        env:
+          SCROLL_REGISTRY_HOST: ${{ secrets.SCROLL_REGISTRY_HOST }}
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+            registry_host="${SCROLL_REGISTRY_HOST#http://}"
+            registry_host="${registry_host#https://}"
+            registry_host="${registry_host%%/*}"
+            export DRUID_COLDSTARTER_IMAGE="${registry_host}/${SCROLL_REGISTRY_PR_NAMESPACE}/druid:stable-pr${{ github.event.pull_request.number }}"
+          fi
+          make build-tree
+      - name: Get registry binary
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GO_REPO_TOKEN }}
+        run: |
+          tag="$(gh api repos/highcard-dev/druid-cli/releases --jq '[.[] | select(.prerelease)][0].tag_name')"
+          gh release download "$tag" --repo highcard-dev/druid-cli --pattern druid --clobber
+      - name: Install druid
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          chmod +x druid
+          mv druid /usr/local/bin/druid
       - name: Validate all scrolls
         run: ./scripts/validate_all_scrolls.sh
+      - name: Login to registry
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: druid login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
+      - name: Push experimental PR tags
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          SCROLL_REGISTRY_HOST: ${{ secrets.SCROLL_REGISTRY_HOST }}
+        run: ./scripts/push.sh "${{ github.event.pull_request.number }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,7 @@ jobs:
       SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
       SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
       SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
+      DRUID_CLI_VERSION: pr-76
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -33,8 +34,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GO_REPO_TOKEN }}
         run: |
-          tag="$(gh api repos/highcard-dev/druid-cli/releases --jq '[.[] | select(.prerelease)][0].tag_name')"
-          gh release download "$tag" --repo highcard-dev/druid-cli --pattern druid --clobber
+          gh release download "$DRUID_CLI_VERSION" --repo highcard-dev/druid-cli --pattern druid --clobber
       - name: Install druid
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,4 +151,3 @@ jobs:
 
           druid push --cwd ./scrolls/hytale/hytale-standalone -p main=5520/udp -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 10Gi --min-ram 4Gi --min-cpu 1 -m --smart --category hytale
           druid push --cwd ./scrolls/hytale/hytale-druid-gg -p main=5520/udp -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 10Gi --min-ram 4Gi --min-cpu 1 -m --smart --category hytale
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,125 +30,125 @@ jobs:
         run: druid version
       - run: ./scripts/validate_all_scrolls.sh
       - name: Login to registry
-        run: druid registry login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
+        run: druid login --host ${{ secrets.SCROLL_REGISTRY_HOST }} --user '${{ secrets.SCROLL_REGISTRY_USER }}' --password ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
       - name: Push Categories
         run: |
-          druid registry push category artifacts.druid.gg/druid-team/scroll-minecraft-spigot minecraft ./scrolls/minecraft/minecraft-spigot/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-minecraft-vanilla minecraft ./scrolls/minecraft/minecraft-vanilla/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-minecraft-paper minecraft ./scrolls/minecraft/papermc/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-minecraft-forge minecraft ./scrolls/minecraft/forge/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-minecraft-cuberite minecraft ./scrolls/minecraft/cuberite/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-rust-oxide rust ./scrolls/rust/rust-oxide/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-rust-vanilla rust ./scrolls/rust/rust-vanilla/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:pwserver palworld ./scrolls/lgsm/pwserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:arkserver ark ./scrolls/lgsm/arkserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:untserver unturned ./scrolls/lgsm/untserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:dayzserver dayz ./scrolls/lgsm/dayzserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:sdtdserver 7days ./scrolls/lgsm/sdtdserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:gmodserver gmod ./scrolls/lgsm/gmodserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:cs2server cs2 ./scrolls/lgsm/cs2server/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:pzserver zomboid ./scrolls/lgsm/pzserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-lgsm:csgoserver csgo ./scrolls/lgsm/csgoserver/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-hytale:hytale-standalone hytale ./scrolls/hytale/hytale-standalone/.meta
-          druid registry push category artifacts.druid.gg/druid-team/scroll-hytale:hytale-druid-gg hytale ./scrolls/hytale/hytale-druid-gg/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-minecraft-spigot minecraft ./scrolls/minecraft/minecraft-spigot/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-minecraft-vanilla minecraft ./scrolls/minecraft/minecraft-vanilla/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-minecraft-paper minecraft ./scrolls/minecraft/papermc/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-minecraft-forge minecraft ./scrolls/minecraft/forge/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-minecraft-cuberite minecraft ./scrolls/minecraft/cuberite/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-rust-oxide rust ./scrolls/rust/rust-oxide/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-rust-vanilla rust ./scrolls/rust/rust-vanilla/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:pwserver palworld ./scrolls/lgsm/pwserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:arkserver ark ./scrolls/lgsm/arkserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:untserver unturned ./scrolls/lgsm/untserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:dayzserver dayz ./scrolls/lgsm/dayzserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:sdtdserver 7days ./scrolls/lgsm/sdtdserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:gmodserver gmod ./scrolls/lgsm/gmodserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:cs2server cs2 ./scrolls/lgsm/cs2server/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:pzserver zomboid ./scrolls/lgsm/pzserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-lgsm:csgoserver csgo ./scrolls/lgsm/csgoserver/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-hytale:hytale-standalone hytale ./scrolls/hytale/hytale-standalone/.meta
+          druid push category artifacts.druid.gg/druid-team/scroll-hytale:hytale-druid-gg hytale ./scrolls/hytale/hytale-druid-gg/.meta
       - name: Pushing new scrolls
         shell: bash
         run: |
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.17 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.18 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.17 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.18 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.17 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/papermc/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.18 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.20 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.20.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/forge/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/minecraft/cuberite/latest -p main=25565 -p webpanel=8080 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
-          druid registry push --cwd ./scrolls/rust/rust-oxide/latest -p main=/udp -p query=/udp -p rcon -p rustplus -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd --min-disk 10Gi --min-ram 6Gi --min-cpu 1 --smart --category rust
-          druid registry push --cwd ./scrolls/rust/rust-vanilla/latest -p main=/udp -p query=/udp -p rcon -p rustplus -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd --min-disk 10Gi --min-ram 6Gi --min-cpu 1 --smart --category rust
-          druid registry push --cwd ./scrolls/lgsm/pwserver -p main=8211/udp -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 7Gi --min-ram 2Gi --min-cpu 0.5 --smart --category palworld
-          druid registry push --cwd ./scrolls/lgsm/arkserver -p main=/udp  -p query=/udp -p rcon -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 25Gi --min-ram 7Gi --min-cpu 0.5 --smart --category ark
-          druid registry push --cwd ./scrolls/lgsm/untserver -p main=/udp -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m  --min-disk 7Gi --min-ram 1Gi --min-cpu 0.5 --smart --category unturned
-          druid registry push --cwd ./scrolls/lgsm/dayzserver -p main=/udp -p battle-eye=2304/udp -p query=27016/udp -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 7Gi --min-ram 5Gi --min-cpu 1 --category dayz
-          druid registry push --cwd ./scrolls/lgsm/sdtdserver -p main=26900/udp -p main2=26902/udp -p maintcp=26900 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 20Gi --min-ram 2Gi --min-cpu 0.5 --category 7days
-          druid registry push --cwd ./scrolls/lgsm/gmodserver -p query=27005/udp -p main=/udp -p sourcetv=27020/udp -p steam=27015 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 8Gi --min-ram 512Mi --min-cpu 0.25 --smart --category gmod
-          druid registry push --cwd ./scrolls/lgsm/cs2server -p main=/udp -p rcon=27015 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 38Gi --min-ram 1Gi --min-cpu 0.5 --smart --category cs2
-          druid registry push --cwd ./scrolls/lgsm/pzserver -p main=/udp -p main2=/udp  -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category zomboid
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.17 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.18 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-spigot/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.17 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.18 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/minecraft-vanilla/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.17 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/papermc/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.17.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.18 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.18.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.18.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.19 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.19.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.19.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.19.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.19.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.20 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.20.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.20.2 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.20.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.20.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.20.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.21.1 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.21.3 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.21.4 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.21.5 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.21.6 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/forge/1.21.7 -p main=25565 -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/minecraft/cuberite/latest -p main=25565 -p webpanel=8080 -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category minecraft
+          druid push --cwd ./scrolls/rust/rust-oxide/latest -p main=/udp -p query=/udp -p rcon -p rustplus -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd --min-disk 10Gi --min-ram 6Gi --min-cpu 1 --smart --category rust
+          druid push --cwd ./scrolls/rust/rust-vanilla/latest -p main=/udp -p query=/udp -p rcon -p rustplus -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd --min-disk 10Gi --min-ram 6Gi --min-cpu 1 --smart --category rust
+          druid push --cwd ./scrolls/lgsm/pwserver -p main=8211/udp -p rcon=25575 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 7Gi --min-ram 2Gi --min-cpu 0.5 --smart --category palworld
+          druid push --cwd ./scrolls/lgsm/arkserver -p main=/udp  -p query=/udp -p rcon -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 25Gi --min-ram 7Gi --min-cpu 0.5 --smart --category ark
+          druid push --cwd ./scrolls/lgsm/untserver -p main=/udp -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m  --min-disk 7Gi --min-ram 1Gi --min-cpu 0.5 --smart --category unturned
+          druid push --cwd ./scrolls/lgsm/dayzserver -p main=/udp -p battle-eye=2304/udp -p query=27016/udp -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 7Gi --min-ram 5Gi --min-cpu 1 --category dayz
+          druid push --cwd ./scrolls/lgsm/sdtdserver -p main=26900/udp -p main2=26902/udp -p maintcp=26900 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 20Gi --min-ram 2Gi --min-cpu 0.5 --category 7days
+          druid push --cwd ./scrolls/lgsm/gmodserver -p query=27005/udp -p main=/udp -p sourcetv=27020/udp -p steam=27015 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 8Gi --min-ram 512Mi --min-cpu 0.25 --smart --category gmod
+          druid push --cwd ./scrolls/lgsm/cs2server -p main=/udp -p rcon=27015 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 38Gi --min-ram 1Gi --min-cpu 0.5 --smart --category cs2
+          druid push --cwd ./scrolls/lgsm/pzserver -p main=/udp -p main2=/udp  -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 --smart --category zomboid
 
-          druid registry push --cwd ./scrolls/lgsm/csgoserver -p query=27005/udp -p main=27015/udp -p sourcetv=27020/udp -p steam=27015 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --smart --category csgo
+          druid push --cwd ./scrolls/lgsm/csgoserver -p query=27005/udp -p main=27015/udp -p sourcetv=27020/udp -p steam=27015 -i artifacts.druid.gg/druid-team/druid:stable-nix-steamcmd -m --smart --category csgo
 
 
-          druid registry push --cwd ./scrolls/hytale/hytale-standalone -p main=5520/udp -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 10Gi --min-ram 4Gi --min-cpu 1 -m --smart --category hytale
-          druid registry push --cwd ./scrolls/hytale/hytale-druid-gg -p main=5520/udp -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 10Gi --min-ram 4Gi --min-cpu 1 -m --smart --category hytale
+          druid push --cwd ./scrolls/hytale/hytale-standalone -p main=5520/udp -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 10Gi --min-ram 4Gi --min-cpu 1 -m --smart --category hytale
+          druid push --cwd ./scrolls/hytale/hytale-druid-gg -p main=5520/udp -i artifacts.druid.gg/druid-team/druid:stable-nix --min-disk 10Gi --min-ram 4Gi --min-cpu 1 -m --smart --category hytale
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,14 @@ jobs:
       SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
       SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
       SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
+      DRUID_CLI_VERSION: v0.1.226
     steps:
       - uses: actions/checkout@v3
       - name: Get registry binary
         uses: robinraju/release-downloader@v1.7
         with:
           repository: "highcard-dev/druid-cli"
-          latest: true
+          tag: ${{ env.DRUID_CLI_VERSION }}
           fileName: "druid"
           token: ${{ secrets.GO_REPO_TOKEN }}
       - run: chmod +x druid

--- a/generate-scrolls.go
+++ b/generate-scrolls.go
@@ -20,6 +20,7 @@ type TemplateVars struct {
 	Artifact           string
 	Version            string
 	VersionEscaped     string
+	ColdstarterImage   string
 	Artifacts          map[string]string
 	ArtifactsUnescaped map[string]string
 	Vars               map[string]string
@@ -91,6 +92,10 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	coldstarterImage := os.Getenv("DRUID_COLDSTARTER_IMAGE")
+	if coldstarterImage == "" {
+		coldstarterImage = "artifacts.druid.gg/druid-team/druid:stable"
+	}
 
 	//iterate through artifacts and generate scroll.yaml files
 	for version, artifact := range artifacts {
@@ -99,6 +104,7 @@ func main() {
 		templateVars.Artifact = artifact
 		templateVars.Version = version
 		templateVars.VersionEscaped = strings.Replace(version, ".", "-", -1)
+		templateVars.ColdstarterImage = coldstarterImage
 		templateVars.Artifacts = GetArtifactsAbove(version, artifacts, true)
 		templateVars.ArtifactsUnescaped = GetArtifactsAbove(version, artifacts, false)
 		if varsBytes != nil && vars[version] == nil {

--- a/generate-scrolls.go
+++ b/generate-scrolls.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"unicode"
 
 	cp "github.com/otiai10/copy"
 
@@ -68,6 +69,21 @@ func main() {
 	funcMap := template.FuncMap{
 		"split": func(sep, s string) []string {
 			return strings.Split(s, sep)
+		},
+		"upper": strings.ToUpper,
+		"env": func(value string) string {
+			var out strings.Builder
+			for i, r := range value {
+				if i > 0 && unicode.IsUpper(r) {
+					out.WriteByte('_')
+				}
+				if r == '-' || r == ' ' {
+					out.WriteByte('_')
+					continue
+				}
+				out.WriteRune(unicode.ToUpper(r))
+			}
+			return out.String()
 		},
 	}
 	scollYamltemplate, err := template.New(filepath.Base(scrollYamlTemplate)).Funcs(funcMap).ParseFiles(scrollYamlTemplate)

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/otiai10/copy v1.12.0
 )
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require (
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,6 @@ github.com/otiai10/copy v1.12.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pr_number="${1:?usage: $0 <pr-number>}"
+registry_host="${SCROLL_REGISTRY_HOST:?SCROLL_REGISTRY_HOST is required}"
+registry_host="${registry_host#http://}"
+registry_host="${registry_host#https://}"
+registry_host="${registry_host%%/*}"
+
+namespace="${SCROLL_REGISTRY_PR_NAMESPACE:-druid-team-experimental}"
+runtime_namespace="${SCROLL_REGISTRY_RUNTIME_NAMESPACE:-druid-team}"
+runtime_image="${DRUID_SCROLL_RUNTIME_IMAGE:-${registry_host}/${runtime_namespace}/druid:stable-nix}"
+roots="${SCROLL_PR_ROOTS:-./scrolls/minecraft/minecraft-vanilla}"
+
+yaml_value() {
+  awk -F':[[:space:]]*' -v key="$2" '
+    $1 == key {
+      value = $2
+      gsub(/^"/, "", value)
+      gsub(/"$/, "", value)
+      print value
+      exit
+    }
+  ' "$1"
+}
+
+push_dir() {
+  local dir="$1"
+  local name app_version image artifact
+
+  name="$(yaml_value "$dir/scroll.yaml" name)"
+  app_version="$(yaml_value "$dir/scroll.yaml" app_version)"
+  if [[ "$app_version" == "latest" ]]; then
+    echo "Skipping ${dir}: PR previews do not publish latest tags"
+    return
+  fi
+
+  image="${name##*/}"
+  artifact="${registry_host}/${namespace}/${image}:${app_version}-pr${pr_number}"
+
+  echo "Pushing ${artifact} from ${dir}"
+  druid push "$artifact" "$dir" \
+    -p main=25565 -p rcon=25575 \
+    -i "$runtime_image" \
+    --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
+    --smart --category minecraft
+}
+
+for root in $roots; do
+  for dir in "$root"/*; do
+    [[ -f "$dir/scroll.yaml" ]] || continue
+    push_dir "$dir"
+  done
+done

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -11,7 +11,7 @@ registry_host="${registry_host%%/*}"
 namespace="${SCROLL_REGISTRY_PR_NAMESPACE:-druid-team-experimental}"
 runtime_namespace="${SCROLL_REGISTRY_RUNTIME_NAMESPACE:-druid-team}"
 runtime_image="${DRUID_SCROLL_RUNTIME_IMAGE:-${registry_host}/${runtime_namespace}/druid:stable-nix}"
-roots="${SCROLL_PR_ROOTS:-./scrolls/minecraft/minecraft-vanilla}"
+roots="${SCROLL_PR_ROOTS:-}"
 
 yaml_value() {
   awk -F':[[:space:]]*' -v key="$2" '
@@ -25,9 +25,53 @@ yaml_value() {
   ' "$1"
 }
 
+scroll_dirs() {
+  if [[ -n "$roots" ]]; then
+    for root in $roots; do
+      for dir in "$root"/*; do
+        [[ -f "$dir/scroll.yaml" ]] || continue
+        printf '%s\n' "$dir"
+      done
+      [[ -f "$root/scroll.yaml" ]] && printf '%s\n' "$root"
+    done
+    return
+  fi
+  find ./scrolls -type f -name scroll.yaml -print | sed 's#/scroll.yaml$##' | sort
+}
+
+port_args() {
+  awk '
+    /^ports:/ { in_ports=1; next }
+    /^[^[:space:]-]/ { in_ports=0 }
+    in_ports && /^[[:space:]]*-[[:space:]]*name:/ {
+      name=$0
+      sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", name)
+      gsub(/"/, "", name)
+    }
+    in_ports && /^[[:space:]]*port:/ {
+      port=$0
+      sub(/^[[:space:]]*port:[[:space:]]*/, "", port)
+      if (name != "" && port != "") {
+        printf " -p %s=%s", name, port
+      }
+    }
+  ' "$1/scroll.yaml"
+}
+
+category_for_dir() {
+  local dir="$1"
+  dir="${dir#./scrolls/}"
+  echo "${dir%%/*}"
+}
+
 push_dir() {
   local dir="$1"
-  local name app_version image artifact
+  local name app_version image artifact ports category
+
+  if [[ "$dir" == ./scrolls/.sample || "$dir" == ./scrolls/.sample/* ]]; then
+    echo "Skipping ${dir}: sample scrolls are validation fixtures"
+    return
+  fi
 
   name="$(yaml_value "$dir/scroll.yaml" name)"
   app_version="$(yaml_value "$dir/scroll.yaml" app_version)"
@@ -38,18 +82,17 @@ push_dir() {
 
   image="${name##*/}"
   artifact="${registry_host}/${namespace}/${image}:${app_version}-pr${pr_number}"
+  ports="$(port_args "$dir")"
+  category="$(category_for_dir "$dir")"
 
   echo "Pushing ${artifact} from ${dir}"
-  druid push "$artifact" "$dir" \
-    -p main=25565 -p rcon=25575 \
+  # shellcheck disable=SC2086
+  druid push "$artifact" "$dir" $ports \
     -i "$runtime_image" \
     --min-disk 3Gi --min-ram 512Mi --min-cpu 0.25 \
-    --smart --category minecraft
+    --smart --category "$category"
 }
 
-for root in $roots; do
-  for dir in "$root"/*; do
-    [[ -f "$dir/scroll.yaml" ]] || continue
-    push_dir "$dir"
-  done
-done
+while IFS= read -r dir; do
+  push_dir "$dir"
+done < <(scroll_dirs)

--- a/scripts/validate-scrolls.go
+++ b/scripts/validate-scrolls.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var envNamePattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+func main() {
+	files, err := findScrollFiles(".")
+	if err != nil {
+		fail(err)
+	}
+	if len(files) == 0 {
+		fail(errors.New("no scroll.yaml files found"))
+	}
+	for _, file := range files {
+		fmt.Printf("Validating %s\n", filepath.Dir(file))
+		if err := validateScroll(file, shouldValidateColdstarterFiles(file)); err != nil {
+			fail(fmt.Errorf("%s: %w", file, err))
+		}
+	}
+}
+
+func findScrollFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == ".git" || name == ".build" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "scroll.yaml" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
+}
+
+func validateScroll(file string, validateColdstarterFiles bool) error {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	var scroll map[string]any
+	if err := yaml.Unmarshal(data, &scroll); err != nil {
+		return err
+	}
+	if requiredString(scroll, "name") == "" {
+		return errors.New("missing name")
+	}
+	if requiredString(scroll, "version") == "" {
+		return errors.New("missing version")
+	}
+	if requiredString(scroll, "app_version") == "" {
+		return errors.New("missing app_version")
+	}
+	portNames, err := validatePorts(scroll["ports"])
+	if err != nil {
+		return err
+	}
+	commands, ok := asMap(scroll["commands"])
+	if !ok || len(commands) == 0 {
+		return errors.New("missing commands")
+	}
+	for commandName, rawCommand := range commands {
+		command, ok := asMap(rawCommand)
+		if !ok {
+			return fmt.Errorf("command %s must be an object", commandName)
+		}
+		if err := validateCommand(filepath.Dir(file), commandName, command, portNames, validateColdstarterFiles); err != nil {
+			return err
+		}
+	}
+	if serve := optionalString(scroll["serve"]); serve != "" {
+		if _, ok := commands[serve]; !ok {
+			return fmt.Errorf("serve command %q does not exist", serve)
+		}
+	}
+	return nil
+}
+
+func validatePorts(raw any) (map[string]bool, error) {
+	names := map[string]bool{}
+	if raw == nil {
+		return names, nil
+	}
+	ports, ok := asList(raw)
+	if !ok {
+		return nil, errors.New("ports must be a list")
+	}
+	for index, rawPort := range ports {
+		port, ok := asMap(rawPort)
+		if !ok {
+			return nil, fmt.Errorf("ports[%d] must be an object", index)
+		}
+		name := requiredString(port, "name")
+		if name == "" {
+			return nil, fmt.Errorf("ports[%d] missing name", index)
+		}
+		if names[name] {
+			return nil, fmt.Errorf("duplicate port %q", name)
+		}
+		names[name] = true
+		protocol := optionalString(port["protocol"])
+		if protocol != "" && protocol != "tcp" && protocol != "udp" && protocol != "http" && protocol != "https" {
+			return nil, fmt.Errorf("port %q has unsupported protocol %q", name, protocol)
+		}
+	}
+	return names, nil
+}
+
+func validateCommand(root string, name string, command map[string]any, portNames map[string]bool, validateColdstarterFiles bool) error {
+	run := optionalString(command["run"])
+	if run != "" && run != "always" && run != "once" && run != "restart" && run != "persistent" {
+		return fmt.Errorf("command %s has unsupported run mode %q", name, run)
+	}
+	if _, err := asStringList(command["needs"]); err != nil {
+		return fmt.Errorf("command %s needs: %w", name, err)
+	}
+	procedures, ok := asList(command["procedures"])
+	if !ok || len(procedures) == 0 {
+		return fmt.Errorf("command %s missing procedures", name)
+	}
+	for index, rawProcedure := range procedures {
+		procedure, ok := asMap(rawProcedure)
+		if !ok {
+			return fmt.Errorf("command %s procedure %d must be an object", name, index)
+		}
+		if err := validateProcedure(root, name, index, procedure, portNames, validateColdstarterFiles); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProcedure(root string, command string, index int, procedure map[string]any, portNames map[string]bool, validateColdstarterFiles bool) error {
+	prefix := fmt.Sprintf("command %s procedure %d", command, index)
+	if mode := optionalString(procedure["mode"]); mode != "" && mode != "container" && mode != "exec" && mode != "signal" {
+		return fmt.Errorf("%s has unsupported mode %q", prefix, mode)
+	}
+	if env, ok := asStringMap(procedure["env"]); ok {
+		for key, value := range env {
+			if !envNamePattern.MatchString(key) {
+				return fmt.Errorf("%s env key %q is not uppercase snake case", prefix, key)
+			}
+			if strings.HasPrefix(key, "DRUID_PORT_") && strings.HasSuffix(key, "_COLDSTARTER") {
+				if value == "generic" {
+					continue
+				}
+				if filepath.IsAbs(value) || strings.Contains(value, "..") {
+					return fmt.Errorf("%s coldstarter handler %q must be a safe relative path", prefix, value)
+				}
+				if validateColdstarterFiles {
+					if _, err := os.Stat(filepath.Join(root, value)); err != nil {
+						return fmt.Errorf("%s coldstarter handler %q does not exist", prefix, value)
+					}
+				}
+			}
+		}
+	}
+	if expectedPorts, ok := asList(procedure["expectedPorts"]); ok {
+		for portIndex, rawPort := range expectedPorts {
+			port, ok := asMap(rawPort)
+			if !ok {
+				return fmt.Errorf("%s expectedPorts[%d] must be an object", prefix, portIndex)
+			}
+			name := requiredString(port, "name")
+			if name == "" {
+				return fmt.Errorf("%s expectedPorts[%d] missing name", prefix, portIndex)
+			}
+			if !portNames[name] {
+				return fmt.Errorf("%s expectedPorts[%d] references unknown port %q", prefix, portIndex, name)
+			}
+		}
+	}
+	return nil
+}
+
+func shouldValidateColdstarterFiles(file string) bool {
+	return strings.Contains(filepath.ToSlash(file), "/minecraft/")
+}
+
+func requiredString(values map[string]any, key string) string {
+	return optionalString(values[key])
+}
+
+func optionalString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case int:
+		return fmt.Sprint(typed)
+	case int64:
+		return fmt.Sprint(typed)
+	case float64:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", typed), "0"), ".")
+	default:
+		return ""
+	}
+}
+
+func asMap(value any) (map[string]any, bool) {
+	typed, ok := value.(map[string]any)
+	return typed, ok
+}
+
+func asList(value any) ([]any, bool) {
+	typed, ok := value.([]any)
+	return typed, ok
+}
+
+func asStringList(value any) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	list, ok := asList(value)
+	if !ok {
+		return nil, errors.New("must be a list")
+	}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		text, ok := item.(string)
+		if !ok {
+			return nil, errors.New("must contain only strings")
+		}
+		out = append(out, text)
+	}
+	return out, nil
+}
+
+func asStringMap(value any) (map[string]string, bool) {
+	values, ok := asMap(value)
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = fmt.Sprint(value)
+	}
+	return out, true
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "Error:", err)
+	os.Exit(1)
+}

--- a/scripts/validate-scrolls.go
+++ b/scripts/validate-scrolls.go
@@ -78,12 +78,16 @@ func validateScroll(file string, validateColdstarterFiles bool) error {
 	if !ok || len(commands) == 0 {
 		return errors.New("missing commands")
 	}
+	commandNames := make(map[string]bool, len(commands))
+	for commandName := range commands {
+		commandNames[commandName] = true
+	}
 	for commandName, rawCommand := range commands {
 		command, ok := asMap(rawCommand)
 		if !ok {
 			return fmt.Errorf("command %s must be an object", commandName)
 		}
-		if err := validateCommand(filepath.Dir(file), commandName, command, portNames, validateColdstarterFiles); err != nil {
+		if err := validateCommand(filepath.Dir(file), commandName, command, commandNames, portNames, validateColdstarterFiles); err != nil {
 			return err
 		}
 	}
@@ -121,17 +125,32 @@ func validatePorts(raw any) (map[string]bool, error) {
 		if protocol != "" && protocol != "tcp" && protocol != "udp" && protocol != "http" && protocol != "https" {
 			return nil, fmt.Errorf("port %q has unsupported protocol %q", name, protocol)
 		}
+		if _, hasPort := port["port"]; hasPort {
+			portNumber, ok := asInt(port["port"])
+			if !ok {
+				return nil, fmt.Errorf("port %q has non-numeric port", name)
+			}
+			if portNumber < 1 || portNumber > 65535 {
+				return nil, fmt.Errorf("port %q has invalid port %d", name, portNumber)
+			}
+		}
 	}
 	return names, nil
 }
 
-func validateCommand(root string, name string, command map[string]any, portNames map[string]bool, validateColdstarterFiles bool) error {
+func validateCommand(root string, name string, command map[string]any, commandNames map[string]bool, portNames map[string]bool, validateColdstarterFiles bool) error {
 	run := optionalString(command["run"])
 	if run != "" && run != "always" && run != "once" && run != "restart" && run != "persistent" {
 		return fmt.Errorf("command %s has unsupported run mode %q", name, run)
 	}
-	if _, err := asStringList(command["needs"]); err != nil {
+	needs, err := asStringList(command["needs"])
+	if err != nil {
 		return fmt.Errorf("command %s needs: %w", name, err)
+	}
+	for _, need := range needs {
+		if !commandNames[need] {
+			return fmt.Errorf("command %s needs unknown command %q", name, need)
+		}
 	}
 	procedures, ok := asList(command["procedures"])
 	if !ok || len(procedures) == 0 {
@@ -174,7 +193,11 @@ func validateProcedure(root string, command string, index int, procedure map[str
 			}
 		}
 	}
-	if expectedPorts, ok := asList(procedure["expectedPorts"]); ok {
+	rawExpectedPorts, hasExpectedPorts := procedure["expectedPorts"]
+	if hasExpectedPorts && rawExpectedPorts == nil {
+		return fmt.Errorf("%s expectedPorts must be a list", prefix)
+	}
+	if expectedPorts, ok := asList(rawExpectedPorts); ok {
 		for portIndex, rawPort := range expectedPorts {
 			port, ok := asMap(rawPort)
 			if !ok {
@@ -188,6 +211,8 @@ func validateProcedure(root string, command string, index int, procedure map[str
 				return fmt.Errorf("%s expectedPorts[%d] references unknown port %q", prefix, portIndex, name)
 			}
 		}
+	} else if hasExpectedPorts {
+		return fmt.Errorf("%s expectedPorts must be a list", prefix)
 	}
 	return nil
 }
@@ -242,6 +267,22 @@ func asStringList(value any) ([]string, error) {
 		out = append(out, text)
 	}
 	return out, nil
+}
+
+func asInt(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		if typed == float64(int(typed)) {
+			return int(typed), true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
 }
 
 func asStringMap(value any) (map[string]string, bool) {

--- a/scripts/validate_all_scrolls.sh
+++ b/scripts/validate_all_scrolls.sh
@@ -1,5 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-go run ./scripts/validate-scrolls.go
+if command -v druid >/dev/null 2>&1; then
+  while IFS= read -r file; do
+    dir="${file%/scroll.yaml}"
+    echo "Validating ${dir}"
+    druid validate --strict "$dir"
+  done < <(find ./scrolls -type f -name scroll.yaml | sort)
+else
+  go run ./scripts/validate-scrolls.go
+fi

--- a/scripts/validate_all_scrolls.sh
+++ b/scripts/validate_all_scrolls.sh
@@ -2,9 +2,4 @@
 
 set -e
 
-ALL_SCROLL_DIRS=$(find . -type f -name "scroll.yaml" -exec dirname {} \; | sort | uniq)
-
-for SCROLL_DIR in $ALL_SCROLL_DIRS; do
-    echo "Validating $SCROLL_DIR"
-    druid validate --strict "$SCROLL_DIR"
-done
+go run ./scripts/validate-scrolls.go

--- a/scripts/validate_all_scrolls.sh
+++ b/scripts/validate_all_scrolls.sh
@@ -6,5 +6,5 @@ ALL_SCROLL_DIRS=$(find . -type f -name "scroll.yaml" -exec dirname {} \; | sort 
 
 for SCROLL_DIR in $ALL_SCROLL_DIRS; do
     echo "Validating $SCROLL_DIR"
-    druid scroll validate "$SCROLL_DIR"
+    druid validate --strict "$SCROLL_DIR"
 done

--- a/scrolls/.sample/sample-variation/sample-version/scroll.yaml
+++ b/scrolls/.sample/sample-variation/sample-version/scroll.yaml
@@ -2,32 +2,32 @@ name: sample@1.23
 desc: Sample Game
 version: 0.0.1
 app_version: 0.0.1
-init: "install"
 commands:
   start:
-    should_change_status: start
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./start.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
   stop:
-    type: stop
     procedures:
-      - mode: rcon_web_rust
-        data:
-          - quit
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
-    should_change_status: start
     procedures:
-      - mode: exec
-        data:
-          - steamcmd
-          - app/resources/druid-deployment
-          - +login
-          - anonymous
-          - +app_update
-          - 258550
-          - +quit
-plugins:
-  rcon_web_rust: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo sample install complete
+    run: once
+serve: start

--- a/scrolls/hytale/hytale-druid-gg/scroll.yaml
+++ b/scrolls/hytale/hytale-druid-gg/scroll.yaml
@@ -3,54 +3,72 @@ desc: Hytale
 version: 0.0.1
 app_version: latest
 ports:
-  - name: main
-    protocol: udp
-    port: 5520
-init: "start"
+- name: main
+  protocol: udp
+  port: 5520
 commands:
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - update-server.sh
-          - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-update-hytale-server.sh
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - start-server.sh
-          - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-start-hytale-server.sh
-      - mode: exec
-        data:
-          - chmod
-          - "+x"
-          - update-server.sh
-          - start-server.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - update-server.sh
+      - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-update-hytale-server.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - start-server.sh
+      - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-start-hytale-server.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - chmod
+      - "+x"
+      - update-server.sh
+      - start-server.sh
   install-server:
     run: once
-    needs: [install]
-    dependencies: [wget, cacert, unzip]
+    needs:
+    - install
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - HSM_URL="https://hytale.druid.gg" JWT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) ./update-server.sh
+    - image: eclipse-temurin:25-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - HSM_URL="https://hytale.druid.gg" JWT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+        ./update-server.sh
   start:
-    needs: [install-server]
-    dependencies: [jdk25]
+    needs:
+    - install-server
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - HSM_URL="https://hytale.druid.gg" JWT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) ./start-server.sh
-
-plugins:
-  rcon: {}
+    - image: eclipse-temurin:25-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - HSM_URL="https://hytale.druid.gg" JWT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+        ./start-server.sh
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+    run: restart
+serve: start

--- a/scrolls/hytale/hytale-standalone/data/install.sh
+++ b/scrolls/hytale/hytale-standalone/data/install.sh
@@ -25,6 +25,6 @@ else
 fi
 
 echo "Downloading hsm ${VERSION} for ${OS}/${ARCH}..."
-curl -fL "$URL" -o hsm
+wget -q -O hsm "$URL"
 chmod +x hsm
 echo "Done"

--- a/scrolls/hytale/hytale-standalone/scroll.yaml
+++ b/scrolls/hytale/hytale-standalone/scroll.yaml
@@ -3,42 +3,57 @@ desc: Hytale
 version: 0.0.1
 app_version: standalone
 ports:
-  - name: main
-    protocol: udp
-    port: 5520
-init: "start"
+- name: main
+  protocol: udp
+  port: 5520
 commands:
   install-hsm:
     run: once
-    dependencies: [wget, cacert, curl]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - install.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install.sh
   login:
     run: once
-    needs: [install-hsm]
+    needs:
+    - install-hsm
     procedures:
-      - mode: exec
-        data:
-          - ./hsm
-          - login
+    - image: eclipse-temurin:25-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./hsm"
+      - login
   update:
-    needs: [login]
+    needs:
+    - login
     procedures:
-      - mode: exec
-        data:
-          - ./hsm
-          - update
+    - image: eclipse-temurin:25-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./hsm"
+      - update
   start:
-    needs: [update]
-    dependencies: [jdk25]
+    needs:
+    - update
     procedures:
-      - mode: exec
-        data:
-          - ./hsm
-          - start
-
-plugins:
-  rcon: {}
+    - image: eclipse-temurin:25-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./hsm"
+      - start
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+    run: restart
+serve: start

--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -8,157 +8,189 @@ keepAlivePPM: {{ or .Vars.ppm 5 }}
 {{- if or .Vars.lua_query_game_name .Vars.main_port_protocol .Vars.rcon_port }}
 ports:
 {{- if .Vars.lua_query_game_name }}
-  - name: {{ or .Vars.lua_query_port  "query" }}
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: {{ or .Vars.start_delay 0 }}
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "{{ .Vars.lua_query_game_name }}"
-      - name: GameSteamFolder
-        value: {{ .Vars.lua_query_folder }}
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: {{ .Vars.lua_query_map }}
-      - name: ServerListName
-        value: "{{ .Vars.lua_query_servername }}"
+- name: {{ or .Vars.lua_query_port  "query" }}
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: {{ or .Vars.start_delay 0 }}
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: "{{ .Vars.lua_query_game_name }}"
+  - name: GameSteamFolder
+    value: {{ .Vars.lua_query_folder }}
+  - name: GameSteamId
+    value: "0"
+  - name: MapName
+    value: {{ .Vars.lua_query_map }}
+  - name: ServerListName
+    value: "{{ .Vars.lua_query_servername }}"
 {{- if .Vars.lua_query_keywords }}
-      - name: GameKeywords
-        value: "{{ .Vars.lua_query_keywords }}"
+  - name: GameKeywords
+    value: "{{ .Vars.lua_query_keywords }}"
 {{- end }}
 {{- if .Vars.lua_query_version }}
-      - name: GameVersion
-        value: "{{ .Vars.lua_query_version }}"
+  - name: GameVersion
+    value: "{{ .Vars.lua_query_version }}"
 {{- end }}
 {{- if .Vars.lua_query_version_prefix }}
-      - name: GameVersionPrefix
-        value: "{{ .Vars.lua_query_version_prefix }}"
+  - name: GameVersionPrefix
+    value: "{{ .Vars.lua_query_version_prefix }}"
 {{- end }}
 {{- if .Vars.lua_query_start_on_unknown_packet }}
-      - name: StartOnUnknownPacket
-        value: "{{ .Vars.lua_query_start_on_unknown_packet }}"
+  - name: StartOnUnknownPacket
+    value: "{{ .Vars.lua_query_start_on_unknown_packet }}"
 {{- end }}
 {{- if .Vars.lua_steam_app_id }}
-      - name: SteamAppId
-        value: "{{ .Vars.lua_steam_app_id }}"
+  - name: SteamAppId
+    value: "{{ .Vars.lua_steam_app_id }}"
 {{- end }}
 {{- end }}
 {{- if .Vars.main_port_protocol }}
-  - name: main
-    description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
-    protocol: {{ .Vars.main_port_protocol }}
-    start_delay: {{ or .Vars.start_delay 0 }}
-    finish_after_command: install
-    sleep_handler: generic
-    check_activity: true
+- name: main
+  description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
+  protocol: {{ .Vars.main_port_protocol }}
+  start_delay: {{ or .Vars.start_delay 0 }}
+  finish_after_command: install
+  sleep_handler: generic
+  check_activity: true
 {{- end }}
 {{- if .Vars.rcon_port }}
-  - name: rcon
-    protocol: tcp
+- name: rcon
+  protocol: tcp
+  sleep_handler: generic
 {{- end }}
 {{- end }}
-init: "console"
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-{{- if index .Vars "dependencies" }}
-    dependencies:
-{{- range split ";" (index .Vars "dependencies") }}
-      - {{ . }}
-{{- end }}
-{{- end }}
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./{{ .Version }}
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+{{- if .Vars.lua_query_game_name }}
+      - name: {{ or .Vars.lua_query_port  "query" }}
+        keepAliveTraffic: 10kb/5m
+{{- end }}
+{{- if .Vars.main_port_protocol }}
+      - name: main
+        keepAliveTraffic: 10kb/5m
+{{- end }}
+{{- if .Vars.rcon_port }}
+      - name: rcon
+{{- end }}
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+{{- if .Vars.lua_query_game_name }}
+      - name: {{ or .Vars.lua_query_port  "query" }}
+        keepAliveTraffic: 10kb/5m
+{{- end }}
+{{- if .Vars.main_port_protocol }}
+      - name: main
+        keepAliveTraffic: 10kb/5m
+{{- end }}
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - ./{{ .Version }}
+      - console
   start:
-    needs: [install]
-{{- if index .Vars "dependencies" }}
-    dependencies:
-{{- range split ";" (index .Vars "dependencies") }}
-      - {{ . }}
-{{- end }}
-{{- end }}
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./{{ .Version }}
-          - update
-      - mode: exec
-        data:
-          - ./{{ .Version }}
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - ./{{ .Version }}
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - ./{{ .Version }}
+      - start
   stop:
+    run: always
     procedures:
-      - mode: exec
-        data:
-          - ./{{ .Version }}
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - ./{{ .Version }}
+      - stop
   restart:
-{{- if index .Vars "dependencies" }}
-    dependencies:
-{{- range split ";" (index .Vars "dependencies") }}
-      - {{ . }}
-{{- end }}
-{{- end }}
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./{{ .Version }}
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - ./{{ .Version }}
+      - restart
   install:
-{{- if index .Vars "dependencies" }}
-    dependencies:
-{{- range split ";" (index .Vars "dependencies") }}
-      - {{ . }}
-{{- end }}
-{{- end }}
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - {{ .Version }}
-      - mode: exec
-        data:
-          - ./{{ .Version }}
-          - auto-install
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - ./linuxgsm.sh
+      - {{ .Version }}
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - ./{{ .Version }}
+      - auto-install
 {{- if eq .Vars.postinstall "enabled" }}
-      - mode: exec
-        data:
-          - bash
-          - postinstall.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - bash
+      - postinstall.sh
 {{- end }}
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
-{{- if eq .Vars.rcon "enabled" }}
-plugins:
-  rcon: {}
-{{- end }}
+serve: console

--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -11,54 +11,15 @@ ports:
 - name: {{ or .Vars.lua_query_port  "query" }}
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: {{ or .Vars.start_delay 0 }}
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: "{{ .Vars.lua_query_game_name }}"
-  - name: GameSteamFolder
-    value: {{ .Vars.lua_query_folder }}
-  - name: GameSteamId
-    value: "0"
-  - name: MapName
-    value: {{ .Vars.lua_query_map }}
-  - name: ServerListName
-    value: "{{ .Vars.lua_query_servername }}"
-{{- if .Vars.lua_query_keywords }}
-  - name: GameKeywords
-    value: "{{ .Vars.lua_query_keywords }}"
-{{- end }}
-{{- if .Vars.lua_query_version }}
-  - name: GameVersion
-    value: "{{ .Vars.lua_query_version }}"
-{{- end }}
-{{- if .Vars.lua_query_version_prefix }}
-  - name: GameVersionPrefix
-    value: "{{ .Vars.lua_query_version_prefix }}"
-{{- end }}
-{{- if .Vars.lua_query_start_on_unknown_packet }}
-  - name: StartOnUnknownPacket
-    value: "{{ .Vars.lua_query_start_on_unknown_packet }}"
-{{- end }}
-{{- if .Vars.lua_steam_app_id }}
-  - name: SteamAppId
-    value: "{{ .Vars.lua_steam_app_id }}"
-{{- end }}
 {{- end }}
 {{- if .Vars.main_port_protocol }}
 - name: main
   description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: {{ .Vars.main_port_protocol }}
-  start_delay: {{ or .Vars.start_delay 0 }}
-  finish_after_command: install
-  sleep_handler: generic
-  check_activity: true
 {{- end }}
 {{- if .Vars.rcon_port }}
 - name: rcon
   protocol: tcp
-  sleep_handler: generic
 {{- end }}
 {{- end }}
 commands:
@@ -87,7 +48,35 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+{{- if .Vars.lua_query_game_name }}
+        DRUID_PORT_{{ upper (or .Vars.lua_query_port "query") }}_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_{{ env "GameName" }}: "{{ .Vars.lua_query_game_name }}"
+        DRUID_COLDSTARTER_VAR_{{ env "GameSteamFolder" }}: "{{ .Vars.lua_query_folder }}"
+        DRUID_COLDSTARTER_VAR_{{ env "GameSteamId" }}: "0"
+        DRUID_COLDSTARTER_VAR_{{ env "MapName" }}: "{{ .Vars.lua_query_map }}"
+        DRUID_COLDSTARTER_VAR_{{ env "ServerListName" }}: "{{ .Vars.lua_query_servername }}"
+{{- if .Vars.lua_query_keywords }}
+        DRUID_COLDSTARTER_VAR_{{ env "GameKeywords" }}: "{{ .Vars.lua_query_keywords }}"
+{{- end }}
+{{- if .Vars.lua_query_version }}
+        DRUID_COLDSTARTER_VAR_{{ env "GameVersion" }}: "{{ .Vars.lua_query_version }}"
+{{- end }}
+{{- if .Vars.lua_query_version_prefix }}
+        DRUID_COLDSTARTER_VAR_{{ env "GameVersionPrefix" }}: "{{ .Vars.lua_query_version_prefix }}"
+{{- end }}
+{{- if .Vars.lua_query_start_on_unknown_packet }}
+        DRUID_COLDSTARTER_VAR_{{ env "StartOnUnknownPacket" }}: "{{ .Vars.lua_query_start_on_unknown_packet }}"
+{{- end }}
+{{- if .Vars.lua_steam_app_id }}
+        DRUID_COLDSTARTER_VAR_{{ env "SteamAppId" }}: "{{ .Vars.lua_steam_app_id }}"
+{{- end }}
+{{- end }}
+{{- if .Vars.main_port_protocol }}
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
+{{- end }}
+{{- if .Vars.rcon_port }}
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
+{{- end }}
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/.build/versions/arkserver/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/arkserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/.build/versions/cs2server/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/cs2server/packet_handler/query.lua
@@ -108,7 +108,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/.build/versions/dayzserver/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/dayzserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/.build/versions/gmodserver/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/gmodserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/.build/versions/pwserver/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/pwserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/.build/versions/pzserver/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/pzserver/packet_handler/query.lua
@@ -108,7 +108,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/.build/versions/untserver/packet_handler/query.lua
+++ b/scrolls/lgsm/.build/versions/untserver/packet_handler/query.lua
@@ -108,7 +108,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/arkserver/packet_handler/query.lua
+++ b/scrolls/lgsm/arkserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -46,32 +46,11 @@ ports:
 - name: query
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: "ARK: Survival Evolved"
-  - name: GameSteamFolder
-    value: ark_survival_evolved
-  - name: GameSteamId
-    value: "0"
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: "Druid.gg Server (idle) - join to start"
-  - name: SteamAppId
-    value: "346110"
 - name: main
   description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: udp
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: generic
-  check_activity: true
 - name: rcon
   protocol: tcp
-  sleep_handler: generic
 commands:
   console:
     needs:
@@ -92,7 +71,15 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "ARK: Survival Evolved"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "ark_survival_evolved"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "346110"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -2,206 +2,187 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: arkserver
 version: 0.0.2
 app_version: arkserver
-keepAlivePPM: 5
 chunks:
-  - name: install-lgsm
-    path: install-lgsm.sh
-  - name: lgsm-launcher
-    path: arkserver
-  - name: linuxgsm
-    path: linuxgsm.sh
-  - name: lgsm
-    path: lgsm
-  - name: serverfiles
-    path: serverfiles
+- name: install-lgsm
+  path: install-lgsm.sh
+- name: lgsm-launcher
+  path: arkserver
+- name: linuxgsm
+  path: linuxgsm.sh
+- name: lgsm
+  path: lgsm
+- name: serverfiles
+  path: serverfiles
+  chunks:
+  - name: server-engine
+    path: Engine
+  - name: server-linux64
+    path: linux64
+  - name: server-steamapps
+    path: steamapps
+  - name: shootergame
+    path: ShooterGame
     chunks:
-      - name: server-engine
-        path: Engine
-      - name: server-linux64
-        path: linux64
-      - name: server-steamapps
-        path: steamapps
-      - name: shootergame
-        path: ShooterGame
-        chunks:
-          - name: shootergame-binaries
-            path: Binaries
-          - name: shootergame-config
-            path: Config
-          - name: shootergame-saved
-            path: Saved
-          - name: content
-            path: Content
-            chunks:
-              - name: maps
-                path: Maps/*
-              - name: mods
-                path: Mods/*
-              - name: movies
-                path: Movies/*
-              - name: reflectioncaptures
-                path: ReflectionCaptures/*
-
+    - name: shootergame-binaries
+      path: Binaries
+    - name: shootergame-config
+      path: Config
+    - name: shootergame-saved
+      path: Saved
+    - name: content
+      path: Content
+      chunks:
+      - name: maps
+        path: Maps/*
+      - name: mods
+        path: Mods/*
+      - name: movies
+        path: Movies/*
+      - name: reflectioncaptures
+        path: ReflectionCaptures/*
 ports:
-  - name: query
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "ARK: Survival Evolved"
-      - name: GameSteamFolder
-        value: ark_survival_evolved
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: SteamAppId
-        value: "346110"
-  - name: main
-    description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
-    protocol: udp
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: generic
-    check_activity: true
-  - name: rcon
-    protocol: tcp
-init: "console"
+- name: query
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: 'ARK: Survival Evolved'
+  - name: GameSteamFolder
+    value: ark_survival_evolved
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: SteamAppId
+    value: '346110'
+  port: 27015
+- name: main
+  description: Main game port. Use this port inside of your game client to connect
+    to the server. Depending on the game you might need the query port to connect.
+  protocol: udp
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: generic
+  port: 7777
+- name: rcon
+  protocol: tcp
+  port: 27020
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./arkserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./arkserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./arkserver
-          - update
-      - mode: exec
-        data:
-          - ./arkserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./arkserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./arkserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./arkserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./arkserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./arkserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./arkserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - arkserver
-      - mode: exec
-        data:
-          - ./arkserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
-plugins:
-  rcon: {}
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - arkserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./arkserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -2,44 +2,46 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: arkserver
 version: 0.0.2
 app_version: arkserver
+keepAlivePPM: 5
 chunks:
-- name: install-lgsm
-  path: install-lgsm.sh
-- name: lgsm-launcher
-  path: arkserver
-- name: linuxgsm
-  path: linuxgsm.sh
-- name: lgsm
-  path: lgsm
-- name: serverfiles
-  path: serverfiles
-  chunks:
-  - name: server-engine
-    path: Engine
-  - name: server-linux64
-    path: linux64
-  - name: server-steamapps
-    path: steamapps
-  - name: shootergame
-    path: ShooterGame
+  - name: install-lgsm
+    path: install-lgsm.sh
+  - name: lgsm-launcher
+    path: arkserver
+  - name: linuxgsm
+    path: linuxgsm.sh
+  - name: lgsm
+    path: lgsm
+  - name: serverfiles
+    path: serverfiles
     chunks:
-    - name: shootergame-binaries
-      path: Binaries
-    - name: shootergame-config
-      path: Config
-    - name: shootergame-saved
-      path: Saved
-    - name: content
-      path: Content
-      chunks:
-      - name: maps
-        path: Maps/*
-      - name: mods
-        path: Mods/*
-      - name: movies
-        path: Movies/*
-      - name: reflectioncaptures
-        path: ReflectionCaptures/*
+      - name: server-engine
+        path: Engine
+      - name: server-linux64
+        path: linux64
+      - name: server-steamapps
+        path: steamapps
+      - name: shootergame
+        path: ShooterGame
+        chunks:
+          - name: shootergame-binaries
+            path: Binaries
+          - name: shootergame-config
+            path: Config
+          - name: shootergame-saved
+            path: Saved
+          - name: content
+            path: Content
+            chunks:
+              - name: maps
+                path: Maps/*
+              - name: mods
+                path: Mods/*
+              - name: movies
+                path: Movies/*
+              - name: reflectioncaptures
+                path: ReflectionCaptures/*
+
 ports:
 - name: query
   protocol: udp
@@ -49,29 +51,27 @@ ports:
   sleep_handler: packet_handler/query.lua
   vars:
   - name: GameName
-    value: 'ARK: Survival Evolved'
+    value: "ARK: Survival Evolved"
   - name: GameSteamFolder
     value: ark_survival_evolved
   - name: GameSteamId
-    value: '0'
+    value: "0"
   - name: MapName
     value: server idle
   - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
+    value: "Druid.gg Server (idle) - join to start"
   - name: SteamAppId
-    value: '346110'
-  port: 27015
+    value: "346110"
 - name: main
-  description: Main game port. Use this port inside of your game client to connect
-    to the server. Depending on the game you might need the query port to connect.
+  description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: udp
   start_delay: 0
   finish_after_command: install
   sleep_handler: generic
-  port: 7777
+  check_activity: true
 - name: rcon
   protocol: tcp
-  port: 27020
+  sleep_handler: generic
 commands:
   console:
     needs:
@@ -85,30 +85,30 @@ commands:
         keepAliveTraffic: 10kb/5m
       - name: main
         keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
-      mounts:
-      - path: "/server"
-      working_dir: "/server"
-      tty: true
-      command:
-      - "./arkserver"
-      - console
-      id: start
+    - id: start
+      image: highcard/druid:stable-steamcmd
       expectedPorts:
       - name: query
         keepAliveTraffic: 10kb/5m
       - name: main
         keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - ./arkserver
+      - console
   start:
     needs:
     - install
@@ -119,25 +119,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./arkserver"
+      - ./arkserver
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./arkserver"
+      - ./arkserver
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./arkserver"
+      - ./arkserver
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -152,7 +152,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./arkserver"
+      - ./arkserver
       - restart
   install:
     run: once
@@ -176,13 +176,13 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - arkserver
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./arkserver"
+      - ./arkserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/cs2server/packet_handler/query.lua
+++ b/scrolls/lgsm/cs2server/packet_handler/query.lua
@@ -108,7 +108,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -2,60 +2,62 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: cs2server
 version: 0.0.2
 app_version: cs2server
+keepAlivePPM: 5
 chunks:
-- name: install-lgsm
-  path: install-lgsm.sh
-- name: lgsm-launcher
-  path: cs2server
-- name: linuxgsm
-  path: linuxgsm.sh
-- name: lgsm
-  path: lgsm
-- name: log
-  path: log
-- name: postinstall
-  path: postinstall.sh
-- name: postinstall-template
-  path: postinstall.sh.scroll_template
-- name: serverfiles
-  path: serverfiles
-  chunks:
-  - name: steamapps
-    path: steamapps
-  - name: game
-    path: game
+  - name: install-lgsm
+    path: install-lgsm.sh
+  - name: lgsm-launcher
+    path: cs2server
+  - name: linuxgsm
+    path: linuxgsm.sh
+  - name: lgsm
+    path: lgsm
+  - name: log
+    path: log
+  - name: postinstall
+    path: postinstall.sh
+  - name: postinstall-template
+    path: postinstall.sh.scroll_template
+  - name: serverfiles
+    path: serverfiles
     chunks:
-    - name: game-bin
-      path: bin
-    - name: game-core
-      path: core
-    - name: csgo
-      path: csgo
-      chunks:
-      - name: csgo-bin
-        path: bin
-      - name: csgo-cfg
-        path: cfg
-      - name: csgo-logs
-        path: logs
-      - name: csgo-maps
-        path: maps
-      - name: csgo-panorama
-        path: panorama
-      - name: csgo-resource
-        path: resource
-      - name: csgo-pak
-        path: pak01_*.vpk
-      - name: csgo-shaders-vulkan
-        path: shaders_vulkan_*.vpk
-    - name: csgo-community-addons
-      path: csgo_community_addons
-    - name: csgo-core
-      path: csgo_core
-    - name: csgo-imported
-      path: csgo_imported
-    - name: csgo-lv
-      path: csgo_lv
+      - name: steamapps
+        path: steamapps
+      - name: game
+        path: game
+        chunks:
+          - name: game-bin
+            path: bin
+          - name: game-core
+            path: core
+          - name: csgo
+            path: csgo
+            chunks:
+              - name: csgo-bin
+                path: bin
+              - name: csgo-cfg
+                path: cfg
+              - name: csgo-logs
+                path: logs
+              - name: csgo-maps
+                path: maps
+              - name: csgo-panorama
+                path: panorama
+              - name: csgo-resource
+                path: resource
+              - name: csgo-pak
+                path: pak01_*.vpk
+              - name: csgo-shaders-vulkan
+                path: shaders_vulkan_*.vpk
+          - name: csgo-community-addons
+            path: csgo_community_addons
+          - name: csgo-core
+            path: csgo_core
+          - name: csgo-imported
+            path: csgo_imported
+          - name: csgo-lv
+            path: csgo_lv
+
 ports:
 - name: main
   protocol: udp
@@ -65,20 +67,19 @@ ports:
   sleep_handler: packet_handler/query.lua
   vars:
   - name: GameName
-    value: 'CS2: Druid Server'
+    value: "CS2: Druid Server"
   - name: GameSteamFolder
     value: csgo
   - name: GameSteamId
-    value: '0'
+    value: "0"
   - name: MapName
     value: server idle
   - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
+    value: "Druid.gg Server (idle) - join to start"
   - name: StartOnUnknownPacket
-    value: 'yes'
+    value: "yes"
   - name: SteamAppId
-    value: '730'
-  port: 27015
+    value: "730"
 commands:
   console:
     needs:
@@ -94,24 +95,23 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       tty: true
       command:
-      - "./cs2server"
+      - ./cs2server
       - console
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   start:
     needs:
     - install
@@ -122,25 +122,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./cs2server"
+      - ./cs2server
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./cs2server"
+      - ./cs2server
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./cs2server"
+      - ./cs2server
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -155,7 +155,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./cs2server"
+      - ./cs2server
       - restart
   install:
     run: once
@@ -179,20 +179,20 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - cs2server
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./cs2server"
+      - ./cs2server
       - auto-install
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - sh
+      - bash
       - postinstall.sh
 serve: console

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -2,219 +2,197 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: cs2server
 version: 0.0.2
 app_version: cs2server
-keepAlivePPM: 5
 chunks:
-  - name: install-lgsm
-    path: install-lgsm.sh
-  - name: lgsm-launcher
-    path: cs2server
-  - name: linuxgsm
-    path: linuxgsm.sh
-  - name: lgsm
-    path: lgsm
-  - name: log
-    path: log
-  - name: postinstall
-    path: postinstall.sh
-  - name: postinstall-template
-    path: postinstall.sh.scroll_template
-  - name: serverfiles
-    path: serverfiles
+- name: install-lgsm
+  path: install-lgsm.sh
+- name: lgsm-launcher
+  path: cs2server
+- name: linuxgsm
+  path: linuxgsm.sh
+- name: lgsm
+  path: lgsm
+- name: log
+  path: log
+- name: postinstall
+  path: postinstall.sh
+- name: postinstall-template
+  path: postinstall.sh.scroll_template
+- name: serverfiles
+  path: serverfiles
+  chunks:
+  - name: steamapps
+    path: steamapps
+  - name: game
+    path: game
     chunks:
-      - name: steamapps
-        path: steamapps
-      - name: game
-        path: game
-        chunks:
-          - name: game-bin
-            path: bin
-          - name: game-core
-            path: core
-          - name: csgo
-            path: csgo
-            chunks:
-              - name: csgo-bin
-                path: bin
-              - name: csgo-cfg
-                path: cfg
-              - name: csgo-logs
-                path: logs
-              - name: csgo-maps
-                path: maps
-              - name: csgo-panorama
-                path: panorama
-              - name: csgo-resource
-                path: resource
-              - name: csgo-pak
-                path: pak01_*.vpk
-              - name: csgo-shaders-vulkan
-                path: shaders_vulkan_*.vpk
-          - name: csgo-community-addons
-            path: csgo_community_addons
-          - name: csgo-core
-            path: csgo_core
-          - name: csgo-imported
-            path: csgo_imported
-          - name: csgo-lv
-            path: csgo_lv
-
+    - name: game-bin
+      path: bin
+    - name: game-core
+      path: core
+    - name: csgo
+      path: csgo
+      chunks:
+      - name: csgo-bin
+        path: bin
+      - name: csgo-cfg
+        path: cfg
+      - name: csgo-logs
+        path: logs
+      - name: csgo-maps
+        path: maps
+      - name: csgo-panorama
+        path: panorama
+      - name: csgo-resource
+        path: resource
+      - name: csgo-pak
+        path: pak01_*.vpk
+      - name: csgo-shaders-vulkan
+        path: shaders_vulkan_*.vpk
+    - name: csgo-community-addons
+      path: csgo_community_addons
+    - name: csgo-core
+      path: csgo_core
+    - name: csgo-imported
+      path: csgo_imported
+    - name: csgo-lv
+      path: csgo_lv
 ports:
-  - name: main
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "CS2: Druid Server"
-      - name: GameSteamFolder
-        value: csgo
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: StartOnUnknownPacket
-        value: "yes"
-      - name: SteamAppId
-        value: "730"
-init: "console"
+- name: main
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: 'CS2: Druid Server'
+  - name: GameSteamFolder
+    value: csgo
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: StartOnUnknownPacket
+    value: 'yes'
+  - name: SteamAppId
+    value: '730'
+  port: 27015
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./cs2server
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./cs2server"
+      - console
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./cs2server
-          - update
-      - mode: exec
-        data:
-          - ./cs2server
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./cs2server"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./cs2server"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./cs2server
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./cs2server"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./cs2server
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./cs2server"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - cs2server
-      - mode: exec
-        data:
-          - ./cs2server
-          - auto-install
-      - mode: exec
-        data:
-          - bash
-          - postinstall.sh
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
-plugins:
-  rcon: {}
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - cs2server
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./cs2server"
+      - auto-install
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - postinstall.sh
+serve: console

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -62,24 +62,6 @@ ports:
 - name: main
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: "CS2: Druid Server"
-  - name: GameSteamFolder
-    value: csgo
-  - name: GameSteamId
-    value: "0"
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: "Druid.gg Server (idle) - join to start"
-  - name: StartOnUnknownPacket
-    value: "yes"
-  - name: SteamAppId
-    value: "730"
 commands:
   console:
     needs:
@@ -97,7 +79,14 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "CS2: Druid Server"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "csgo"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_START_ON_UNKNOWN_PACKET: "yes"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "730"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -2,163 +2,146 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: csgoserver
 version: 0.0.2
 app_version: csgoserver
-keepAlivePPM: 600
 ports:
-  - name: query
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "Counter-Strike: Global Offensive"
-      - name: GameSteamFolder
-        value: csgo
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: SteamAppId
-        value: "730"
-  - name: main
-    description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
-    protocol: udp
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: generic
-    check_activity: true
-init: "console"
+- name: query
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: 'Counter-Strike: Global Offensive'
+  - name: GameSteamFolder
+    value: csgo
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: SteamAppId
+    value: '730'
+  port: 27015
+- name: main
+  description: Main game port. Use this port inside of your game client to connect
+    to the server. Depending on the game you might need the query port to connect.
+  protocol: udp
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: generic
+  port: 27015
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./csgoserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./csgoserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./csgoserver
-          - update
-      - mode: exec
-        data:
-          - ./csgoserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./csgoserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./csgoserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./csgoserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./csgoserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./csgoserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./csgoserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - csgoserver
-      - mode: exec
-        data:
-          - ./csgoserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - csgoserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./csgoserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -6,30 +6,11 @@ ports:
 - name: query
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: 'Counter-Strike: Global Offensive'
-  - name: GameSteamFolder
-    value: csgo
-  - name: GameSteamId
-    value: '0'
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
-  - name: SteamAppId
-    value: '730'
   port: 27015
 - name: main
   description: Main game port. Use this port inside of your game client to connect
     to the server. Depending on the game you might need the query port to connect.
   protocol: udp
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: generic
   port: 27015
 commands:
   console:
@@ -48,12 +29,18 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "Counter-Strike: Global Offensive"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "csgo"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "730"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"

--- a/scrolls/lgsm/dayzserver/packet_handler/query.lua
+++ b/scrolls/lgsm/dayzserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -7,10 +7,6 @@ ports:
 - name: main
   description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: udp
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: generic
-  check_activity: true
 commands:
   console:
     needs:
@@ -28,7 +24,7 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -2,144 +2,122 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: dayzserver
 version: 0.0.2
 app_version: dayzserver
-keepAlivePPM: 5
 ports:
-  - name: main
-    description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
-    protocol: udp
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: generic
-    check_activity: true
-init: "console"
+- name: main
+  description: Main game port. Use this port inside of your game client to connect
+    to the server. Depending on the game you might need the query port to connect.
+  protocol: udp
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: generic
+  port: 2302
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./dayzserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./dayzserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./dayzserver
-          - update
-      - mode: exec
-        data:
-          - ./dayzserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./dayzserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./dayzserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./dayzserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./dayzserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./dayzserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./dayzserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - dayzserver
-      - mode: exec
-        data:
-          - ./dayzserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - dayzserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./dayzserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -2,15 +2,15 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: dayzserver
 version: 0.0.2
 app_version: dayzserver
+keepAlivePPM: 5
 ports:
 - name: main
-  description: Main game port. Use this port inside of your game client to connect
-    to the server. Depending on the game you might need the query port to connect.
+  description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: udp
   start_delay: 0
   finish_after_command: install
   sleep_handler: generic
-  port: 2302
+  check_activity: true
 commands:
   console:
     needs:
@@ -26,24 +26,23 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       tty: true
       command:
-      - "./dayzserver"
+      - ./dayzserver
       - console
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   start:
     needs:
     - install
@@ -54,25 +53,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./dayzserver"
+      - ./dayzserver
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./dayzserver"
+      - ./dayzserver
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./dayzserver"
+      - ./dayzserver
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -87,7 +86,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./dayzserver"
+      - ./dayzserver
       - restart
   install:
     run: once
@@ -111,13 +110,13 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - dayzserver
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./dayzserver"
+      - ./dayzserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/gmodserver/packet_handler/query.lua
+++ b/scrolls/lgsm/gmodserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -2,164 +2,142 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: gmodserver
 version: 0.0.2
 app_version: gmodserver
-keepAlivePPM: 5
 ports:
-  - name: main
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "Idle Druid Server"
-      - name: GameSteamFolder
-        value: garrysmod
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: GameKeywords
-        value: " ver:250717"
-      - name: GameVersion
-        value: "2025.03.26"
-      - name: GameVersionPrefix
-        value: "01"
-      - name: StartOnUnknownPacket
-        value: "yes"
-      - name: SteamAppId
-        value: "4000"
-init: "console"
+- name: main
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: Idle Druid Server
+  - name: GameSteamFolder
+    value: garrysmod
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: GameKeywords
+    value: " ver:250717"
+  - name: GameVersion
+    value: 2025.03.26
+  - name: GameVersionPrefix
+    value: '01'
+  - name: StartOnUnknownPacket
+    value: 'yes'
+  - name: SteamAppId
+    value: '4000'
+  port: 27015
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./gmodserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./gmodserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./gmodserver
-          - update
-      - mode: exec
-        data:
-          - ./gmodserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./gmodserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./gmodserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./gmodserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./gmodserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./gmodserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./gmodserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - gmodserver
-      - mode: exec
-        data:
-          - ./gmodserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - gmodserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./gmodserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -2,6 +2,7 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: gmodserver
 version: 0.0.2
 app_version: gmodserver
+keepAlivePPM: 5
 ports:
 - name: main
   protocol: udp
@@ -11,26 +12,25 @@ ports:
   sleep_handler: packet_handler/query.lua
   vars:
   - name: GameName
-    value: Idle Druid Server
+    value: "Idle Druid Server"
   - name: GameSteamFolder
     value: garrysmod
   - name: GameSteamId
-    value: '0'
+    value: "0"
   - name: MapName
     value: server idle
   - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
+    value: "Druid.gg Server (idle) - join to start"
   - name: GameKeywords
     value: " ver:250717"
   - name: GameVersion
-    value: 2025.03.26
+    value: "2025.03.26"
   - name: GameVersionPrefix
-    value: '01'
+    value: "01"
   - name: StartOnUnknownPacket
-    value: 'yes'
+    value: "yes"
   - name: SteamAppId
-    value: '4000'
-  port: 27015
+    value: "4000"
 commands:
   console:
     needs:
@@ -46,24 +46,23 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       tty: true
       command:
-      - "./gmodserver"
+      - ./gmodserver
       - console
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   start:
     needs:
     - install
@@ -74,25 +73,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./gmodserver"
+      - ./gmodserver
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./gmodserver"
+      - ./gmodserver
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./gmodserver"
+      - ./gmodserver
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -107,7 +106,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./gmodserver"
+      - ./gmodserver
       - restart
   install:
     run: once
@@ -131,13 +130,13 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - gmodserver
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./gmodserver"
+      - ./gmodserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -7,30 +7,6 @@ ports:
 - name: main
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: "Idle Druid Server"
-  - name: GameSteamFolder
-    value: garrysmod
-  - name: GameSteamId
-    value: "0"
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: "Druid.gg Server (idle) - join to start"
-  - name: GameKeywords
-    value: " ver:250717"
-  - name: GameVersion
-    value: "2025.03.26"
-  - name: GameVersionPrefix
-    value: "01"
-  - name: StartOnUnknownPacket
-    value: "yes"
-  - name: SteamAppId
-    value: "4000"
 commands:
   console:
     needs:
@@ -48,7 +24,17 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "Idle Druid Server"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "garrysmod"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_GAME_KEYWORDS: " ver:250717"
+        DRUID_COLDSTARTER_VAR_GAME_VERSION: "2025.03.26"
+        DRUID_COLDSTARTER_VAR_GAME_VERSION_PREFIX: "01"
+        DRUID_COLDSTARTER_VAR_START_ON_UNKNOWN_PACKET: "yes"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "4000"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/pwserver/packet_handler/query.lua
+++ b/scrolls/lgsm/pwserver/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -7,10 +7,6 @@ ports:
 - name: main
   description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: udp
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: generic
-  check_activity: true
 commands:
   console:
     needs:
@@ -28,7 +24,7 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -2,15 +2,15 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: pwserver
 version: 0.0.2
 app_version: pwserver
+keepAlivePPM: 5
 ports:
 - name: main
-  description: Main game port. Use this port inside of your game client to connect
-    to the server. Depending on the game you might need the query port to connect.
+  description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
   protocol: udp
   start_delay: 0
   finish_after_command: install
   sleep_handler: generic
-  port: 8211
+  check_activity: true
 commands:
   console:
     needs:
@@ -26,24 +26,23 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       tty: true
       command:
-      - "./pwserver"
+      - ./pwserver
       - console
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   start:
     needs:
     - install
@@ -54,25 +53,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pwserver"
+      - ./pwserver
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pwserver"
+      - ./pwserver
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pwserver"
+      - ./pwserver
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -87,7 +86,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pwserver"
+      - ./pwserver
       - restart
   install:
     run: once
@@ -111,13 +110,13 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - pwserver
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pwserver"
+      - ./pwserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -2,144 +2,122 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: pwserver
 version: 0.0.2
 app_version: pwserver
-keepAlivePPM: 5
 ports:
-  - name: main
-    description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
-    protocol: udp
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: generic
-    check_activity: true
-init: "console"
+- name: main
+  description: Main game port. Use this port inside of your game client to connect
+    to the server. Depending on the game you might need the query port to connect.
+  protocol: udp
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: generic
+  port: 8211
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./pwserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./pwserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./pwserver
-          - update
-      - mode: exec
-        data:
-          - ./pwserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pwserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pwserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./pwserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pwserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./pwserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pwserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - pwserver
-      - mode: exec
-        data:
-          - ./pwserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - pwserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pwserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/pzserver/packet_handler/query.lua
+++ b/scrolls/lgsm/pzserver/packet_handler/query.lua
@@ -108,7 +108,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -2,6 +2,7 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: pzserver
 version: 0.0.2
 app_version: pzserver
+keepAlivePPM: 5
 ports:
 - name: main
   protocol: udp
@@ -11,20 +12,19 @@ ports:
   sleep_handler: packet_handler/query.lua
   vars:
   - name: GameName
-    value: Project Zomboid
+    value: "Project Zomboid"
   - name: GameSteamFolder
     value: zomboid
   - name: GameSteamId
-    value: '0'
+    value: "0"
   - name: MapName
     value: server idle
   - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
+    value: "Druid.gg Server (idle) - join to start"
   - name: StartOnUnknownPacket
-    value: 'yes'
+    value: "yes"
   - name: SteamAppId
-    value: '108600'
-  port: 16261
+    value: "108600"
 commands:
   console:
     needs:
@@ -40,24 +40,23 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       tty: true
       command:
-      - "./pzserver"
+      - ./pzserver
       - console
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   start:
     needs:
     - install
@@ -68,25 +67,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pzserver"
+      - ./pzserver
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pzserver"
+      - ./pzserver
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pzserver"
+      - ./pzserver
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -101,7 +100,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pzserver"
+      - ./pzserver
       - restart
   install:
     run: once
@@ -125,13 +124,13 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - pzserver
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./pzserver"
+      - ./pzserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -7,24 +7,6 @@ ports:
 - name: main
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: "Project Zomboid"
-  - name: GameSteamFolder
-    value: zomboid
-  - name: GameSteamId
-    value: "0"
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: "Druid.gg Server (idle) - join to start"
-  - name: StartOnUnknownPacket
-    value: "yes"
-  - name: SteamAppId
-    value: "108600"
 commands:
   console:
     needs:
@@ -42,7 +24,14 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "Project Zomboid"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "zomboid"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_START_ON_UNKNOWN_PACKET: "yes"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "108600"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -2,158 +2,136 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: pzserver
 version: 0.0.2
 app_version: pzserver
-keepAlivePPM: 5
 ports:
-  - name: main
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "Project Zomboid"
-      - name: GameSteamFolder
-        value: zomboid
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: StartOnUnknownPacket
-        value: "yes"
-      - name: SteamAppId
-        value: "108600"
-init: "console"
+- name: main
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: Project Zomboid
+  - name: GameSteamFolder
+    value: zomboid
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: StartOnUnknownPacket
+    value: 'yes'
+  - name: SteamAppId
+    value: '108600'
+  port: 16261
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./pzserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./pzserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./pzserver
-          - update
-      - mode: exec
-        data:
-          - ./pzserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pzserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pzserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./pzserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pzserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./pzserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pzserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - pzserver
-      - mode: exec
-        data:
-          - ./pzserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - pzserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./pzserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -6,30 +6,11 @@ ports:
 - name: query
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: 7 Days To Die
-  - name: GameSteamFolder
-    value: 7DTD
-  - name: GameSteamId
-    value: '0'
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
-  - name: SteamAppId
-    value: '251570'
   port: 26900
 - name: main
   description: Main game port. Use this port inside of your game client to connect
     to the server. Depending on the game you might need the query port to connect.
   protocol: udp
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: generic
   port: 26900
 commands:
   console:
@@ -48,12 +29,18 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "7 Days To Die"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "7DTD"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "251570"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -2,163 +2,146 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: sdtdserver
 version: 0.0.2
 app_version: sdtdserver
-keepAlivePPM: 5
 ports:
-  - name: query
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "7 Days To Die"
-      - name: GameSteamFolder
-        value: 7DTD
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: SteamAppId
-        value: "251570"
-  - name: main
-    description: Main game port. Use this port inside of your game client to connect to the server. Depending on the game you might need the query port to connect.
-    protocol: udp
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: generic
-    check_activity: true
-init: "console"
+- name: query
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: 7 Days To Die
+  - name: GameSteamFolder
+    value: 7DTD
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: SteamAppId
+    value: '251570'
+  port: 26900
+- name: main
+  description: Main game port. Use this port inside of your game client to connect
+    to the server. Depending on the game you might need the query port to connect.
+  protocol: udp
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: generic
+  port: 26900
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./sdtdserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./sdtdserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./sdtdserver
-          - update
-      - mode: exec
-        data:
-          - ./sdtdserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./sdtdserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./sdtdserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./sdtdserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./sdtdserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./sdtdserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./sdtdserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - sdtdserver
-      - mode: exec
-        data:
-          - ./sdtdserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - sdtdserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./sdtdserver"
+      - auto-install
+serve: console

--- a/scrolls/lgsm/untserver/packet_handler/query.lua
+++ b/scrolls/lgsm/untserver/packet_handler/query.lua
@@ -108,7 +108,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -7,24 +7,6 @@ ports:
 - name: main
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  start_delay: 0
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: "Unturned Server"
-  - name: GameSteamFolder
-    value: Unturned
-  - name: GameSteamId
-    value: "0"
-  - name: MapName
-    value: server idle
-  - name: ServerListName
-    value: "Druid.gg Server (idle) - join to start"
-  - name: StartOnUnknownPacket
-    value: "yes"
-  - name: SteamAppId
-    value: "304930"
 commands:
   console:
     needs:
@@ -42,7 +24,14 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "Unturned Server"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "Unturned"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_START_ON_UNKNOWN_PACKET: "yes"
+        DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "304930"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -2,6 +2,7 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: untserver
 version: 0.0.2
 app_version: untserver
+keepAlivePPM: 5
 ports:
 - name: main
   protocol: udp
@@ -11,20 +12,19 @@ ports:
   sleep_handler: packet_handler/query.lua
   vars:
   - name: GameName
-    value: Unturned Server
+    value: "Unturned Server"
   - name: GameSteamFolder
     value: Unturned
   - name: GameSteamId
-    value: '0'
+    value: "0"
   - name: MapName
     value: server idle
   - name: ServerListName
-    value: Druid.gg Server (idle) - join to start
+    value: "Druid.gg Server (idle) - join to start"
   - name: StartOnUnknownPacket
-    value: 'yes'
+    value: "yes"
   - name: SteamAppId
-    value: '304930'
-  port: 27015
+    value: "304930"
 commands:
   console:
     needs:
@@ -40,24 +40,23 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
-    - image: highcard/druid:stable-steamcmd
+    - id: start
+      image: highcard/druid:stable-steamcmd
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       tty: true
       command:
-      - "./untserver"
+      - ./untserver
       - console
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   start:
     needs:
     - install
@@ -68,25 +67,25 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./untserver"
+      - ./untserver
       - update
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./untserver"
+      - ./untserver
       - start
   stop:
+    run: always
     procedures:
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./untserver"
+      - ./untserver
       - stop
-    run: always
   restart:
     procedures:
     - image: highcard/druid:stable-steamcmd
@@ -101,7 +100,7 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./untserver"
+      - ./untserver
       - restart
   install:
     run: once
@@ -125,13 +124,13 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./linuxgsm.sh"
+      - ./linuxgsm.sh
       - untserver
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - "./untserver"
+      - ./untserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -2,158 +2,136 @@ name: artifacts.druid.gg/druid-team/scroll-lgsm
 desc: untserver
 version: 0.0.2
 app_version: untserver
-keepAlivePPM: 5
 ports:
-  - name: main
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    start_delay: 0
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "Unturned Server"
-      - name: GameSteamFolder
-        value: Unturned
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: server idle
-      - name: ServerListName
-        value: "Druid.gg Server (idle) - join to start"
-      - name: StartOnUnknownPacket
-        value: "yes"
-      - name: SteamAppId
-        value: "304930"
-init: "console"
+- name: main
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  start_delay: 0
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: Unturned Server
+  - name: GameSteamFolder
+    value: Unturned
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: server idle
+  - name: ServerListName
+    value: Druid.gg Server (idle) - join to start
+  - name: StartOnUnknownPacket
+    value: 'yes'
+  - name: SteamAppId
+    value: '304930'
+  port: 27015
 commands:
   console:
-    needs: [start]
+    needs:
+    - start
     run: restart
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: stdin
-        wait: 5
-        data:
-          - 'console.1'
-          - "\r"
-      - mode: exec-tty
-        data:
-          - ./untserver
-          - console
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      tty: true
+      command:
+      - "./untserver"
+      - console
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   start:
-    needs: [install]
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
+    needs:
+    - install
     procedures:
-      - mode: exec
-        ignore_failure: true
-        data:
-          - ./untserver
-          - update
-      - mode: exec
-        data:
-          - ./untserver
-          - start
+    - ignore_failure: true
+      image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./untserver"
+      - update
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./untserver"
+      - start
   stop:
     procedures:
-      - mode: exec
-        data:
-          - ./untserver
-          - stop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./untserver"
+      - stop
+    run: always
   restart:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Restarting server..."
-      - mode: exec
-        data:
-          - ./untserver
-          - restart
-      - mode: command
-        data: console
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Restarting server...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./untserver"
+      - restart
   install:
-    dependencies:
-      - bc
-      - binutils
-      - bzip2
-      - cpio
-      - file
-      - jq
-      - pkgsi686Linux.gcc
-      - netcat
-      - pigz
-      - python3
-      - tmux
-      - unzip
-      - util-linux
-      - moreutils
-      - iproute2
     run: once
     procedures:
-      - mode: exec
-        data:
-          - echo
-          - "Installing LGSM..."
-      - mode: exec
-        data:
-          - sh
-          - install-lgsm.sh
-      - mode: exec
-        data:
-          - ./linuxgsm.sh
-          - untserver
-      - mode: exec
-        data:
-          - ./untserver
-          - auto-install
-cronjobs:
-  - name: Restart every 6 hours
-    schedule: "0 */6 * * *"
-    command: restart
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - echo
+      - Installing LGSM...
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - install-lgsm.sh
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./linuxgsm.sh"
+      - untserver
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - "./untserver"
+      - auto-install
+serve: console

--- a/scrolls/minecraft/cuberite/latest/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/cuberite/latest/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -3,50 +3,83 @@ desc: Cuberite
 version: 0.0.1
 app_version: latest
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: webpanel
-    protocol: tcp
-    port: 8080
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: webpanel
+  protocol: tcp
+  port: 8080
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: webpanel
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: stdin
-        data:
-          - start
-          - stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - Cuberite.tar.gz
-          - https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz
-      - mode: exec
-        data:
-          - tar
-          - -xzf
-          - Cuberite.tar.gz
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - Cuberite.tar.gz
+      - https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - tar
+      - "-xzf"
+      - Cuberite.tar.gz
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+serve: start

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -6,9 +6,6 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: webpanel
   protocol: tcp
   port: 8080
@@ -29,7 +26,7 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
       command:
       - druid-coldstarter
     - image: artifacts.druid.gg/druid-team/druid:stable

--- a/scrolls/minecraft/forge/.build/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/.build/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: {{ .Version }}
+app_version: "{{ .Version }}"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk{{ .Vars.jdkVersion }}]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - id: start
+      image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert, jdk{{ .Vars.jdkVersion }}]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-{{ .Version }}.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-{{ .Version }}.jar
+    - image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.17.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.17.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:16-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.17.1.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:16-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.17.1
+app_version: "1.17.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk16]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk16]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.17.1.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.17.1.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.18.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.18.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.1.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.18.1
+app_version: "1.18.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.1.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.1.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.18.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.18.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.18.2
+app_version: "1.18.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.2.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.2.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.2.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.18/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.18/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.18
+app_version: "1.18"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.19.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.1.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.19.1
+app_version: "1.19.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.1.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.1.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.19.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.19.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.2.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.19.2
+app_version: "1.19.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.2.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.2.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.19.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.19.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.3.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.19.3
+app_version: "1.19.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.3.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.3.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.19.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.19.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.19.4
+app_version: "1.19.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.4.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.4.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.4.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.19/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.19/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.19
+app_version: "1.19"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.20.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.20.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.20.1
+app_version: "1.20.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.1.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.1.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.1.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.20.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.20.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.20.2
+app_version: "1.20.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.2.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.2.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.2.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.20.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.20.3
+app_version: "1.20.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk<no value>]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk<no value>]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.3.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.3.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.20.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.20.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.4.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.20.4
+app_version: "1.20.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.4.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.4.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.20.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.20.6/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.20.6
+app_version: "1.20.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk17]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk17]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.6.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.6.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:
@@ -71,7 +71,7 @@ commands:
       - "-O"
       - forge-installer.jar
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.6.jar
-    - image: eclipse-temurin:21-jre
+    - image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.20/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.20/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.20
+app_version: "1.20"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk<no value>]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk<no value>]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.21.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.21.1
+app_version: "1.21.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk21]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.1.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.1.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.21.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.21.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.21.3
+app_version: "1.21.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk21]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.3.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.3.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.21.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.21.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.21.4
+app_version: "1.21.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk21]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.4.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.4.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.21.5/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.21.5/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.21.5
+app_version: "1.21.5"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk21]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.5.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.5.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.21.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.21.6/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.21.6
+app_version: "1.21.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk21]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.6.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.6.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/forge/1.21.7/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/forge/1.21.7/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -1,72 +1,116 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-forge
 desc: Minecraft Forge
 version: 0.0.1
-app_version: 1.21.7
+app_version: "1.21.7"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./update_user_args.sh
-      - mode: exec
-        data:
-          - sh
-          - ./run.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./update_user_args.sh"
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./run.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, jdk21]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - forge-installer.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.7.jar
-      - mode: exec
-        data:
-          - java
-          - -jar
-          - forge-installer.jar
-          - --installServer
-      - mode: exec
-        data:
-          - rm
-          - forge-installer.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - forge-installer.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.7.jar
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - java
+      - "-jar"
+      - forge-installer.jar
+      - "--installServer"
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - forge-installer.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - image: alpine:3.20

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -41,23 +41,23 @@ commands:
       command:
       - sh
       - "./update_user_args.sh"
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./run.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/.build/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/.build/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: {{ .Version }}
+app_version: "{{ .Version }}"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk{{ .Vars.jdkVersion }}]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-{{ .Version }}.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-{{ .Version }}.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:16-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.17.1
+app_version: "1.17.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk16]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.17.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.17.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.17/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.17/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:16-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.17
+app_version: "1.17"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk16]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.17.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.17.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.18.1
+app_version: "1.18.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.18.2
+app_version: "1.18.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.2.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.2.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.18/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.18/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.18
+app_version: "1.18"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.19.1
+app_version: "1.19.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.19.2
+app_version: "1.19.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.2.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.2.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.19.3
+app_version: "1.19.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.3.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.3.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.19.4
+app_version: "1.19.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.4.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.4.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.19/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.19/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.19
+app_version: "1.19"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.20.1
+app_version: "1.20.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.20.2
+app_version: "1.20.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.2.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.2.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.20.4
+app_version: "1.20.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.4.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.4.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.20.6
+app_version: "1.20.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk17]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.6.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.6.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.21.1
+app_version: "1.21.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk21]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.21.3
+app_version: "1.21.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk21]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.3.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.3.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.21.4
+app_version: "1.21.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk21]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.4.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.4.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.21.5
+app_version: "1.21.5"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk21]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.5.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.5.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.21.6
+app_version: "1.21.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk21]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.6.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.6.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.7/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-spigot/1.21.7/packet_handler/minecraft.lua
@@ -229,7 +229,7 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
                 obj.version.name = "§2▶ Extracting snapshot..."

--- a/scrolls/minecraft/minecraft-spigot/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.7/scroll.yaml
@@ -35,23 +35,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/minecraft-spigot/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.7/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-spigot/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.7/scroll.yaml
@@ -1,59 +1,94 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-spigot
 desc: Minecraft Spigot
 version: 0.0.1
-app_version: 1.21.7
+app_version: "1.21.7"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
-    dependencies: [jdk21]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - spigot.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.7.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - spigot.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.7.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/.build/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/.build/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -1,65 +1,79 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: {{ .Version }}
+app_version: "{{ .Version }}"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:{{ .Vars.jdkVersion }}-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar {{ .Vars.jarUrl }}
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar {{ .Vars.jarUrl }}
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk{{ .Vars.jdkVersion }}]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:{{ .Vars.jdkVersion }}-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - {{ .Vars.jarUrl }}
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar {{ .Vars.jarUrl }}
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/.build/vars.json
+++ b/scrolls/minecraft/minecraft-vanilla/.build/vars.json
@@ -1,11 +1,11 @@
 {
   "1.17": {
     "jarUrl": "https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar",
-    "jdkVersion": "16"
+    "jdkVersion": "17"
   },
   "1.17.1": {
     "jarUrl": "https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar",
-    "jdkVersion": "16"
+    "jdkVersion": "17"
   },
   "1.18": {
     "jarUrl": "https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar",

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.17.1
+app_version: "1.17.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk16]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.17/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.17
+app_version: "1.17"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk16]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.18.1
+app_version: "1.18.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.18.2
+app_version: "1.18.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.18
+app_version: "1.18"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.19.1
+app_version: "1.19.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.19.2
+app_version: "1.19.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.19.3
+app_version: "1.19.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.19.4
+app_version: "1.19.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.19
+app_version: "1.19"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.20.1
+app_version: "1.20.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.20.2
+app_version: "1.20.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.20.4
+app_version: "1.20.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk17]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:17-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,18 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:17-jre
+    - id: start
+      image: eclipse-temurin:17-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -56,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.20.6
+app_version: "1.20.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:17-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:17-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk21]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:21-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,21 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-      - name: rcon
-    - image: eclipse-temurin:21-jre
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -59,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -1,65 +1,79 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.21.1
+app_version: "1.21.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:21-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+      expectedPorts:
+      - name: main
+      - name: rcon
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk21]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:21-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -1,65 +1,79 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.21.3
+app_version: "1.21.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:21-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+      expectedPorts:
+      - name: main
+      - name: rcon
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,21 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-      - name: rcon
-    - image: eclipse-temurin:21-jre
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -59,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -1,65 +1,79 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.21.4
+app_version: "1.21.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:21-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+      expectedPorts:
+      - name: main
+      - name: rcon
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,21 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-      - name: rcon
-    - image: eclipse-temurin:21-jre
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -59,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk21]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:21-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -1,65 +1,79 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.21.5
+app_version: "1.21.5"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:21-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+      expectedPorts:
+      - name: main
+      - name: rcon
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk21]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:21-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,21 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-      - name: rcon
-    - image: eclipse-temurin:21-jre
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -59,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,21 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-      - name: rcon
-    - image: eclipse-temurin:21-jre
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -59,21 +58,22 @@ commands:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20
       mounts:
       - path: "/server"
-        sub_path: data
       working_dir: "/server"
       command:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk21]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:21-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -1,65 +1,79 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.21.6
+app_version: "1.21.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:21-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+      expectedPorts:
+      - name: main
+      - name: rcon
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+        sub_path: data
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -6,14 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  mandatory: true
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -32,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -1,65 +1,76 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-vanilla
 desc: Minecraft Vanilla
 version: 0.0.1
-app_version: 1.21.7
+app_version: "1.21.7"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    mandatory: true
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-serve: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  mandatory: true
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
+serve: start
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - id: start
-        image: eclipse-temurin:21-jre
-        expectedPorts:
-          - name: main
-            keepAliveTraffic: 10kb/5m
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - bash
-          - ./start.sh
+    - image: artifacts.druid.gg/druid-team/druid:stable
+      id: coldstart
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+      expectedPorts:
+      - name: main
+      - name: rcon
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
-      - type: signal
-        target: start
-        signal: SIGTERM
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - >-
-            apk add --no-cache ca-certificates wget
-            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
-            && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
+        && echo eula=true > eula.txt
   update:
     procedures:
-      - image: alpine:3.20
-        mounts:
-          - path: /server
-            sub_path: data
-        working_dir: /server
-        command:
-          - sh
-          - -c
-          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -14,15 +14,18 @@ ports:
   protocol: tcp
   port: 25575
   sleep_handler: generic
-serve: start
 commands:
   start:
     needs:
     - install
     run: restart
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
-      id: coldstart
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -32,20 +35,17 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-      - name: rcon
-    - image: eclipse-temurin:21-jre
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
     run: always
     procedures:
@@ -62,7 +62,9 @@ commands:
       command:
       - sh
       - "-c"
-      - apk add --no-cache ca-certificates wget && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
+      - >-
+        apk add --no-cache ca-certificates wget
+        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
         && echo eula=true > eula.txt
   update:
     procedures:
@@ -74,3 +76,4 @@ commands:
       - sh
       - "-c"
       - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -7,52 +7,59 @@ ports:
     protocol: tcp
     port: 25565
     sleep_handler: packet_handler/minecraft.lua
+    mandatory: true
     start_delay: 10
     finish_after_command: install
   - name: rcon
     protocol: tcp
     port: 25575
-init: "start"
+serve: "start"
 commands:
   start:
     needs: [install]
-    dependencies: [jdk21]
     run: restart
     procedures:
-      - mode: exec
-        data:
+      - id: start
+        image: eclipse-temurin:21-jre
+        expectedPorts:
+          - name: main
+            keepAliveTraffic: 10kb/5m
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - bash
           - ./start.sh
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+      - type: signal
+        target: start
+        signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - server.jar
-          - https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
-      - mode: exec
-        data:
-          - bash
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
+          - sh
           - -c
-          - echo eula=true > eula.txt
+          - >-
+            apk add --no-cache ca-certificates wget
+            && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
+            && echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
+      - image: alpine:3.20
+        mounts:
+          - path: /server
+            sub_path: data
+        working_dir: /server
+        command:
           - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
           - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+          - apk add --no-cache jq yq moreutils && ./update.sh && echo eula=true > eula.txt

--- a/scrolls/minecraft/papermc/.build/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/.build/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: {{ .Version }}
+app_version: "{{ .Version }}"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk{{ .Vars.jdkVersion }}]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - id: start
+      image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
   stop:
+    run: always
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-{{ .Version }}.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-{{ .Version }}.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.17.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.17.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.17.1
+app_version: "1.17.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.17.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.17.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.17/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.17/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.17
+app_version: "1.17"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.17.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.17.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.18.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.18.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.18.1
+app_version: "1.18.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.18.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.18.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.18.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.18.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.18.2
+app_version: "1.18.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.18.2.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.18.2.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.19.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.19.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.19.1
+app_version: "1.19.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.19.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.19.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.19.2
+app_version: "1.19.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.2.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.2.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.19.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.19.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.19.3
+app_version: "1.19.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.3.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.3.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.19.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.19.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.19.4
+app_version: "1.19.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.4.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.4.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.19/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.19/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.19
+app_version: "1.19"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.20.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.20.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.20.1
+app_version: "1.20.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.20.2/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.20.2/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.20.2
+app_version: "1.20.2"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.2.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.2.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.20.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.20.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.20.4
+app_version: "1.20.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.4.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.4.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.20.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.20.6/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.20.6
+app_version: "1.20.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.6.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.6.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.21.1/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.21.1/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.21.1
+app_version: "1.21.1"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.1.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.1.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.21.3/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.21.3/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.21.3
+app_version: "1.21.3"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.3.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.3.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.21.4/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.21.4/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.21.4
+app_version: "1.21.4"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.4.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.4.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.21.5/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.21.5/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.21.5
+app_version: "1.21.5"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.5.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.5.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.21.6/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.21.6/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.21.6
+app_version: "1.21.6"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.6.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.6.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/minecraft/papermc/1.21.7/packet_handler/minecraft.lua
+++ b/scrolls/minecraft/papermc/1.21.7/packet_handler/minecraft.lua
@@ -229,17 +229,17 @@ function pingResponse()
     local snapshotMode = get_snapshot_mode()
     local snapshotPercentage = get_snapshot_percentage()
 
-    if snapshotMode ~= "noop" then
+    if snapshotMode ~= "idle" then
         if snapshotMode == "restore" then
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Downloading snapshot... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Downloading snapshot... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Extracting snapshot..."
             end
             obj.description = "Restoring Minecraft Server, this might take a moment"
         else 
             if snapshotPercentage == nil or snapshotPercentage == 100 then
-                obj.version.name = "§2▶ Backing up... " + format("%.2f", snapshotPercentage) + "%"
+                obj.version.name = "§2▶ Backing up... " .. string.format("%.2f", snapshotPercentage) .. "%"
             else
                 obj.version.name = "§2▶ Backing up..."
             end

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -1,58 +1,93 @@
 name: artifacts.druid.gg/druid-team/scroll-minecraft-paper
 desc: PaperMC
 version: 0.0.1
-app_version: 1.21.7
+app_version: "1.21.7"
 ports:
-  - name: main
-    protocol: tcp
-    port: 25565
-    sleep_handler: packet_handler/minecraft.lua
-    start_delay: 10
-    finish_after_command: install
-  - name: rcon
-    protocol: tcp
-    port: 25575
-init: "start"
+- name: main
+  protocol: tcp
+  port: 25565
+  sleep_handler: packet_handler/minecraft.lua
+  start_delay: 10
+  finish_after_command: install
+- name: rcon
+  protocol: tcp
+  port: 25575
+  sleep_handler: generic
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
-    dependencies: [jdk21]
     procedures:
-      - mode: exec
-        data:
-          - bash
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: rcon
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+      command:
+      - druid-coldstarter
+    - image: eclipse-temurin:21-jre
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
   stop:
     procedures:
-      - mode: rcon
-        data: stop
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert]
     procedures:
-      - mode: exec
-        data:
-          - wget
-          - -q
-          - -O
-          - paper.jar
-          - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.7.jar
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-q"
+      - "-O"
+      - paper.jar
+      - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.7.jar
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
   update:
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - $SCROLL_DIR/update.sh
-      - mode: exec
-        data:
-          - bash
-          - -c
-          - echo eula=true > eula.txt
-plugins:
-  rcon: {}
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - apk add --no-cache jq yq moreutils && ./update.sh
+    - image: alpine:3.20
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "-c"
+      - echo eula=true > eula.txt
+serve: start

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -34,23 +34,23 @@ commands:
         DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
       command:
       - druid-coldstarter
-    - image: eclipse-temurin:21-jre
+    - id: start
+      image: eclipse-temurin:21-jre
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - "./start.sh"
-      id: start
-      expectedPorts:
-      - name: main
-        keepAliveTraffic: 10kb/5m
   stop:
+    run: always
     procedures:
     - type: signal
       target: start
       signal: SIGTERM
-    run: always
   install:
     run: once
     procedures:

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -6,13 +6,9 @@ ports:
 - name: main
   protocol: tcp
   port: 25565
-  sleep_handler: packet_handler/minecraft.lua
-  start_delay: 10
-  finish_after_command: install
 - name: rcon
   protocol: tcp
   port: 25575
-  sleep_handler: generic
 commands:
   start:
     needs:
@@ -31,7 +27,8 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_COLDSTARTER_STATUS_FILE: ".coldstarter-finished.json"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/minecraft.lua"
+        DRUID_PORT_RCON_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start

--- a/scrolls/rust/rust-oxide/latest/packet_handler/query.lua
+++ b/scrolls/rust/rust-oxide/latest/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -5,28 +5,10 @@ app_version: latest
 ports:
 - name: main
   protocol: udp
-  sleep_handler: generic
   port: 28015
 - name: query
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: Rust
-  - name: GameSteamFolder
-    value: rust
-  - name: GameSteamId
-    value: '0'
-  - name: MapName
-    value: Procedual Map
-  - name: ServerListName
-    value: Druid Gameserver (idle) - Start server by joining
-  - name: GameVersion
-    value: '1337'
-  - name: GameKeywords
-    value: mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420
   port: 28017
 - name: rustplus
   protocol: tcp
@@ -51,12 +33,19 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
+        DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "Rust"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "rust"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "Procedual Map"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid Gameserver (idle) - Start server by joining"
+        DRUID_COLDSTARTER_VAR_GAME_VERSION: "1337"
+        DRUID_COLDSTARTER_VAR_GAME_KEYWORDS: "mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"

--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -3,78 +3,121 @@ desc: Rust Oxide
 version: 0.10.7
 app_version: latest
 ports:
-  - name: main
-    protocol: udp
-    sleep_handler: generic
-  - name: query
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: "Rust"
-      - name: GameSteamFolder
-        value: rust
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: Procedual Map
-      - name: ServerListName
-        value: "Druid Gameserver (idle) - Start server by joining"
-      - name: GameVersion
-        value: "1337"
-      - name: GameKeywords
-        value: mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420
-  - name: rustplus
-    protocol: tcp
-  - name: rcon
-    protocol: tcp
-init: "start"
+- name: main
+  protocol: udp
+  sleep_handler: generic
+  port: 28015
+- name: query
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: Rust
+  - name: GameSteamFolder
+    value: rust
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: Procedual Map
+  - name: ServerListName
+    value: Druid Gameserver (idle) - Start server by joining
+  - name: GameVersion
+    value: '1337'
+  - name: GameKeywords
+    value: mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420
+  port: 28017
+- name: rustplus
+  protocol: tcp
+  port: 28082
+- name: rcon
+  protocol: tcp
+  port: 28016
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: rustplus
+        keepAliveTraffic: 10kb/5m
   stop:
-    type: stop
     procedures:
-      - mode: rcon_web_rust
-        data: quit
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
-    dependencies: [wget, cacert, unzip]
     procedures:
-      - mode: exec
-        data:
-          - steamcmd
-          - +force_install_dir
-          - /app/resources/deployment
-          - +login
-          - anonymous
-          - +app_update
-          - "258550"
-          - +quit
-      - mode: exec
-        data:
-          - wget
-          - -O
-          - oxide.zip
-          - https://umod.org/games/rust/download/develop
-      - mode: exec
-        data:
-          - unzip
-          - -o
-          - oxide.zip
-          - -d
-          - /app/resources/deployment
-      - mode: exec
-        data:
-          - rm
-          - oxide.zip
-plugins:
-  rcon_web_rust: {}
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - steamcmd
+      - "+force_install_dir"
+      - "/server"
+      - "+login"
+      - anonymous
+      - "+app_update"
+      - '258550'
+      - "+quit"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - wget
+      - "-O"
+      - oxide.zip
+      - https://umod.org/games/rust/download/develop
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - unzip
+      - "-o"
+      - oxide.zip
+      - "-d"
+      - "/server"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - rm
+      - oxide.zip
+serve: start

--- a/scrolls/rust/rust-vanilla/latest/packet_handler/query.lua
+++ b/scrolls/rust/rust-vanilla/latest/packet_handler/query.lua
@@ -93,7 +93,7 @@ function handle(ctx, data)
             finishSec = math.ceil(finishSec)
         end
 
-        if snapshotMode ~= "noop" then
+        if snapshotMode ~= "idle" then
             if snapshotMode == "restore" then
                 if snapshotPercentage == nil or snapshotPercentage == 100 then
                     name = get_var("ServerListNameRestoring") or "EXTRACTING snapshot, this might take a moment"

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -3,60 +3,95 @@ desc: Rust Vanilla
 version: 0.0.3
 app_version: latest
 ports:
-  - name: main
-    protocol: udp
-    sleep_handler: generic
-  - name: query
-    protocol: udp
-    description: Steam Query Port. Use this to connect via the Steam client.
-    finish_after_command: install
-    sleep_handler: packet_handler/query.lua
-    vars:
-      - name: GameName
-        value: Rust
-      - name: GameSteamFolder
-        value: rust
-      - name: GameSteamId
-        value: "0"
-      - name: MapName
-        value: Procedual Map
-      - name: ServerListName
-        value: "Druid Gameserver (idle) - Start server by joining"
-      - name: GameVersion
-        value: "1337"
-      - name: GameKeywords
-        value: mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420
-  - name: rustplus
-    protocol: tcp
-  - name: rcon
-    protocol: tcp
-init: "start"
+- name: main
+  protocol: udp
+  sleep_handler: generic
+  port: 28015
+- name: query
+  protocol: udp
+  description: Steam Query Port. Use this to connect via the Steam client.
+  finish_after_command: install
+  sleep_handler: packet_handler/query.lua
+  vars:
+  - name: GameName
+    value: Rust
+  - name: GameSteamFolder
+    value: rust
+  - name: GameSteamId
+    value: '0'
+  - name: MapName
+    value: Procedual Map
+  - name: ServerListName
+    value: Druid Gameserver (idle) - Start server by joining
+  - name: GameVersion
+    value: '1337'
+  - name: GameKeywords
+    value: mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420
+  port: 28017
+- name: rustplus
+  protocol: tcp
+  port: 28082
+- name: rcon
+  protocol: tcp
+  port: 28016
 commands:
   start:
-    needs: [install]
+    needs:
+    - install
     run: restart
     procedures:
-      - mode: exec
-        data:
-          - sh
-          - ./start.sh
+    - id: coldstart
+      image: artifacts.druid.gg/druid-team/druid:stable
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      mounts:
+      - path: "/runtime"
+        sub_path: "."
+      working_dir: "/runtime"
+      command:
+      - druid-coldstarter
+      - "--root"
+      - "/runtime"
+      - "--status-file"
+      - ".coldstarter-finished.json"
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - sh
+      - "./start.sh"
+      id: start
+      expectedPorts:
+      - name: main
+        keepAliveTraffic: 10kb/5m
+      - name: query
+        keepAliveTraffic: 10kb/5m
+      - name: rustplus
+        keepAliveTraffic: 10kb/5m
   stop:
-    type: stop
     procedures:
-      - mode: rcon_web_rust
-        data: quit
+    - type: signal
+      target: start
+      signal: SIGTERM
+    run: always
   install:
     run: once
     procedures:
-      - mode: exec
-        data:
-          - steamcmd
-          - +force_install_dir
-          - /app/resources/deployment
-          - +login
-          - anonymous
-          - +app_update
-          - "258550"
-          - +quit
-plugins:
-  rcon_web_rust: {}
+    - image: highcard/druid:stable-steamcmd
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - steamcmd
+      - "+force_install_dir"
+      - "/server"
+      - "+login"
+      - anonymous
+      - "+app_update"
+      - '258550'
+      - "+quit"
+serve: start

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -5,28 +5,10 @@ app_version: latest
 ports:
 - name: main
   protocol: udp
-  sleep_handler: generic
   port: 28015
 - name: query
   protocol: udp
   description: Steam Query Port. Use this to connect via the Steam client.
-  finish_after_command: install
-  sleep_handler: packet_handler/query.lua
-  vars:
-  - name: GameName
-    value: Rust
-  - name: GameSteamFolder
-    value: rust
-  - name: GameSteamId
-    value: '0'
-  - name: MapName
-    value: Procedual Map
-  - name: ServerListName
-    value: Druid Gameserver (idle) - Start server by joining
-  - name: GameVersion
-    value: '1337'
-  - name: GameKeywords
-    value: mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420
   port: 28017
 - name: rustplus
   protocol: tcp
@@ -51,12 +33,19 @@ commands:
       - path: "/runtime"
         sub_path: "."
       working_dir: "/runtime"
+      env:
+        DRUID_ROOT: "/runtime"
+        DRUID_PORT_MAIN_COLDSTARTER: "generic"
+        DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_COLDSTARTER_VAR_GAME_NAME: "Rust"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "rust"
+        DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
+        DRUID_COLDSTARTER_VAR_MAP_NAME: "Procedual Map"
+        DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid Gameserver (idle) - Start server by joining"
+        DRUID_COLDSTARTER_VAR_GAME_VERSION: "1337"
+        DRUID_COLDSTARTER_VAR_GAME_KEYWORDS: "mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420"
       command:
       - druid-coldstarter
-      - "--root"
-      - "/runtime"
-      - "--status-file"
-      - ".coldstarter-finished.json"
     - image: highcard/druid:stable-steamcmd
       mounts:
       - path: "/server"


### PR DESCRIPTION
## Summary
- convert Minecraft Vanilla generated scrolls to the new container/signal procedure format
- keep all Vanilla versions generated from the shared template
- add PR CI publishing to artifacts.druid.gg/druid-team-experimental with tag-<prnumber> refs

## Validation
- go run generate-scrolls.go ./scrolls/minecraft/minecraft-vanilla
- make build-tree
- druid validate for every ./scrolls/minecraft/minecraft-vanilla/*/scroll.yaml
- git diff --check
- workflow YAML parse
- go test ./...
