### PR TITLE
fix(minecraft): enforce runtime keepalive policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Scrolls Registry
+
+## keepAliveTraffic
+
+On Kubernetes runtimes, `keepAliveTraffic` is an enforcement rule for job procedures. If the configured Hubble traffic window elapses with no observed flow for the expected port, druid stops that procedure cleanly and lets the command run mode decide what runs next.
+
+For Minecraft coldstarter scrolls, attach `keepAliveTraffic` to the real runtime procedure's `main` expected port. Do not attach it to the coldstarter procedure; the standby listener must remain available while idle.

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:stable
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1b/60m
       - name: rcon
       mounts:
       - path: "/server"


### PR DESCRIPTION
## Summary
- move Vanilla Minecraft keepAliveTraffic to the runtime start procedure
- set runtime idle policy to 1b/60m
- document keepAliveTraffic enforcement and coldstarter placement

## Validation
- go run ./scripts/validate-scrolls.go