### PR TITLE
fix(minecraft): tighten vanilla keepalive policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## keepAliveTraffic
 
-On Kubernetes runtimes, `keepAliveTraffic` is an enforcement rule for job procedures. If the configured Hubble traffic window elapses with no observed flow for the expected port, druid stops that procedure cleanly and lets the command run mode decide what runs next.
+On Kubernetes runtimes, `keepAliveTraffic` is an enforcement rule for job procedures. If the configured pod RX-byte window elapses below the expected traffic threshold, druid stops that procedure cleanly and lets the command run mode decide what runs next.
 
 For Minecraft coldstarter scrolls, attach `keepAliveTraffic` to the real runtime procedure's `main` expected port. Do not attach it to the coldstarter procedure; the standby listener must remain available while idle.
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 On Kubernetes runtimes, `keepAliveTraffic` is an enforcement rule for job procedures. If the configured Hubble traffic window elapses with no observed flow for the expected port, druid stops that procedure cleanly and lets the command run mode decide what runs next.
 
 For Minecraft coldstarter scrolls, attach `keepAliveTraffic` to the real runtime procedure's `main` expected port. Do not attach it to the coldstarter procedure; the standby listener must remain available while idle.
+
+Minecraft scrolls should use `10kb/5m` on the real runtime `main` port. Server-list pings are small and should not keep a runtime warm; active clients generate recurring keep-alive/play traffic and should keep the runtime alive.

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1b/60m
+        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/server"


### PR DESCRIPTION
## Summary
- set Vanilla Minecraft runtime main-port keepAliveTraffic to `10kb/5m` across versions
- document the Minecraft-specific keepAliveTraffic recommendation

## Research notes
- Minecraft server-list pings use the status handshake/request/ping path and are small probes, so they should not keep a full runtime warm.
- Connected clients generate recurring keep-alive/play traffic, so active sessions should keep the runtime alive.
- This aligns Vanilla with existing Paper/Spigot/Forge Minecraft scroll policy.

## Validation
- `go run ./scripts/validate-scrolls.go`
- `git diff --check`
