### PR TITLE
fix: materialize prebuild script templates

### DIFF
--- a/scripts/prebuild/main.go
+++ b/scripts/prebuild/main.go
@@ -169,12 +169,35 @@ func runProcedure(root string, spec prebuildSpec, mounts *dockerMountSet, index 
 	if proc.WorkingDir != "" {
 		args = append(args, "-w", proc.WorkingDir)
 	}
-	args = append(args, "--entrypoint", proc.Command[0], proc.Image)
-	args = append(args, proc.Command[1:]...)
+	entrypoint, commandArgs := prebuildCommand(proc.Command)
+	args = append(args, "--entrypoint", entrypoint, proc.Image)
+	args = append(args, commandArgs...)
 
 	fmt.Printf("Running install procedure %d with %s\n", index, proc.Image)
 	return run("docker", args...)
 }
+
+func prebuildCommand(command []string) (string, []string) {
+	if len(command) >= 2 && isShell(command[0]) && !strings.HasPrefix(command[1], "-") && filepath.Ext(command[1]) == ".sh" {
+		args := []string{"-lc", templateBackedScriptWrapper, command[0]}
+		args = append(args, command[1:]...)
+		return "sh", args
+	}
+	return command[0], command[1:]
+}
+
+func isShell(value string) bool {
+	base := filepath.Base(value)
+	return base == "sh" || base == "bash"
+}
+
+const templateBackedScriptWrapper = `script="$1"
+shift
+if [ ! -f "$script" ] && [ -f "$script.scroll_template" ]; then
+  cp "$script.scroll_template" "$script"
+  chmod +x "$script"
+fi
+exec "$0" "$script" "$@"`
 
 func mountHostPath(root string, m mount) string {
 	if m.SubPath == "." {

--- a/scripts/prebuild/main_test.go
+++ b/scripts/prebuild/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestPrebuildCommandWrapsTemplateBackedScripts(t *testing.T) {
+	entrypoint, args := prebuildCommand([]string{"bash", "postinstall.sh"})
+	if entrypoint != "sh" {
+		t.Fatalf("entrypoint = %q, want sh", entrypoint)
+	}
+	if len(args) != 4 {
+		t.Fatalf("args = %#v", args)
+	}
+	if args[0] != "-lc" || args[1] != templateBackedScriptWrapper || args[2] != "bash" || args[3] != "postinstall.sh" {
+		t.Fatalf("args = %#v", args)
+	}
+}
+
+func TestPrebuildCommandLeavesRegularCommandsUntouched(t *testing.T) {
+	entrypoint, args := prebuildCommand([]string{"./cs2server", "auto-install"})
+	if entrypoint != "./cs2server" {
+		t.Fatalf("entrypoint = %q, want ./cs2server", entrypoint)
+	}
+	if len(args) != 1 || args[0] != "auto-install" {
+		t.Fatalf("args = %#v", args)
+	}
+}
+
+func TestPrebuildCommandLeavesShellFlagsUntouched(t *testing.T) {
+	entrypoint, args := prebuildCommand([]string{"sh", "-c", "echo ok"})
+	if entrypoint != "sh" {
+		t.Fatalf("entrypoint = %q, want sh", entrypoint)
+	}
+	if len(args) != 2 || args[0] != "-c" || args[1] != "echo ok" {
+		t.Fatalf("args = %#v", args)
+	}
+}


### PR DESCRIPTION
## Summary
- Materialize missing shell scripts from matching .scroll_template files inside prebuild Docker volumes before execution
- Cover command rewriting with focused unit tests

## Validation
- go test ./scripts/prebuild
- ./scripts/validate_all_scrolls.sh
- git diff --check