### PR TITLE
ci: serialize steam prebuilds

### DIFF
--- a/.github/workflows/prebuild-lsm.yml
+++ b/.github/workflows/prebuild-lsm.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: [self-hosted, nauen]
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         target: ${{ fromJson(needs.resolve-targets.outputs.targets) }}
     env:
@@ -42,6 +43,20 @@ jobs:
       PREBUILD_DOCKER_PLATFORM: linux/amd64
     steps:
       - uses: actions/checkout@v3
+      - name: Preflight disk cleanup
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"
+          df -h
+          rm -rf .prebuild-tmp
+          docker ps -aq --filter "name=^/druid-prebuild-" | xargs -r docker rm -f
+          docker volume ls -q --filter "name=^druid-prebuild-" | xargs -r docker volume rm -f
+          docker container prune -f
+          docker volume prune -f
+          docker builder prune -af
+          docker image prune -af
+          echo "Disk after cleanup:"
+          df -h
       - uses: actions/setup-go@v5
         with:
           go-version: ">=1.22.3"
@@ -72,3 +87,15 @@ jobs:
           SCROLL_REGISTRY_HOST: ${{ secrets.SCROLL_REGISTRY_HOST }}
           SCROLL_REGISTRY_USER: ${{ secrets.SCROLL_REGISTRY_USER }}
           SCROLL_REGISTRY_PASSWORD: ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
+      - name: Post-build disk cleanup
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf .prebuild-tmp
+          docker ps -aq --filter "name=^/druid-prebuild-" | xargs -r docker rm -f
+          docker volume ls -q --filter "name=^druid-prebuild-" | xargs -r docker volume rm -f
+          docker container prune -f
+          docker volume prune -f
+          docker builder prune -af
+          docker image prune -af
+          df -h


### PR DESCRIPTION
## Summary
- run Steam prebuild targets one at a time on the self-hosted runner
- clean prebuild temp roots and Docker leftovers before and after each target
- print disk usage around cleanup so runner pressure is visible in logs

## Validation
- go test ./scripts/prebuild
- ./scripts/validate_all_scrolls.sh
- git diff --check