### PR TITLE
fix: remove prebuild runner prune steps

### DIFF
--- a/.github/workflows/prebuild-lsm.yml
+++ b/.github/workflows/prebuild-lsm.yml
@@ -43,20 +43,6 @@ jobs:
       PREBUILD_DOCKER_PLATFORM: linux/amd64
     steps:
       - uses: actions/checkout@v3
-      - name: Preflight disk cleanup
-        run: |
-          set -euo pipefail
-          echo "Disk before cleanup:"
-          df -h
-          rm -rf .prebuild-tmp
-          docker ps -aq --filter "name=^/druid-prebuild-" | xargs -r docker rm -f
-          docker volume ls -q --filter "name=^druid-prebuild-" | xargs -r docker volume rm -f
-          docker container prune -f
-          docker volume prune -f
-          docker builder prune -af
-          docker image prune -af
-          echo "Disk after cleanup:"
-          df -h
       - uses: actions/setup-go@v5
         with:
           go-version: ">=1.22.3"
@@ -87,15 +73,3 @@ jobs:
           SCROLL_REGISTRY_HOST: ${{ secrets.SCROLL_REGISTRY_HOST }}
           SCROLL_REGISTRY_USER: ${{ secrets.SCROLL_REGISTRY_USER }}
           SCROLL_REGISTRY_PASSWORD: ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
-      - name: Post-build disk cleanup
-        if: always()
-        run: |
-          set -euo pipefail
-          rm -rf .prebuild-tmp
-          docker ps -aq --filter "name=^/druid-prebuild-" | xargs -r docker rm -f
-          docker volume ls -q --filter "name=^druid-prebuild-" | xargs -r docker volume rm -f
-          docker container prune -f
-          docker volume prune -f
-          docker builder prune -af
-          docker image prune -af
-          df -h


### PR DESCRIPTION
## Summary
- remove broad Docker prune cleanup from the Steam prebuild workflow
- keep the prebuild script responsible for targeted temporary directory cleanup

## Validation
- `rg "Preflight disk cleanup|Post-build disk cleanup|docker .*prune|builder prune|image prune|volume prune|container prune" .github scripts || true`
- `git diff --check`