### PR TITLE
fix: start LGSM server in console procedure

### DIFF
--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -90,8 +90,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./{{ .Version }}
-      - console
+      - sh
+      - -lc
+      - ./{{ .Version }} start && exec ./{{ .Version }} console
   start:
     needs:
     - install

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -97,8 +97,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./arkserver
-      - console
+      - sh
+      - -lc
+      - ./arkserver start && exec ./arkserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -103,8 +103,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./cs2server
-      - console
+      - sh
+      - -lc
+      - ./cs2server start && exec ./cs2server console
   start:
     needs:
     - install

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -59,8 +59,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./csgoserver
-      - console
+      - sh
+      - -lc
+      - ./csgoserver start && exec ./csgoserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -45,8 +45,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./dayzserver
-      - console
+      - sh
+      - -lc
+      - ./dayzserver start && exec ./dayzserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -58,8 +58,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./gmodserver
-      - console
+      - sh
+      - -lc
+      - ./gmodserver start && exec ./gmodserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -41,8 +41,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./pwserver
-      - console
+      - sh
+      - -lc
+      - ./pwserver start && exec ./pwserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -51,8 +51,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./pzserver
-      - console
+      - sh
+      - -lc
+      - ./pzserver start && exec ./pzserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -59,8 +59,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./sdtdserver
-      - console
+      - sh
+      - -lc
+      - ./sdtdserver start && exec ./sdtdserver console
   start:
     needs:
     - install

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -48,8 +48,9 @@ commands:
       working_dir: "/server"
       tty: true
       command:
-      - ./untserver
-      - console
+      - sh
+      - -lc
+      - ./untserver start && exec ./untserver console
   start:
     needs:
     - install


### PR DESCRIPTION
## Summary
- start LGSM servers inside the long-lived console procedure before attaching console
- keep generated LGSM scrolls in sync with the template
- fixes Kubernetes coldstarter wake where the prior start job ran in a separate pod and left the console pod with no running server

## Validation
- make build-tree
- ./scripts/validate_all_scrolls.sh
- git diff --check