### PR TITLE
fix: configure pzserver admin password

### DIFF
--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -92,7 +92,11 @@ commands:
       command:
       - sh
       - -lc
+{{- if eq .Version "pzserver" }}
+      - sh configure-pzserver.sh && ./{{ .Version }} start && exec ./{{ .Version }} console
+{{- else }}
       - ./{{ .Version }} start && exec ./{{ .Version }} console
+{{- end }}
   start:
     needs:
     - install
@@ -110,8 +114,14 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+{{- if eq .Version "pzserver" }}
+      - sh
+      - -lc
+      - sh configure-pzserver.sh && ./{{ .Version }} start
+{{- else }}
       - ./{{ .Version }}
       - start
+{{- end }}
   stop:
     run: always
     procedures:

--- a/scrolls/lgsm/.build/versions/pzserver/data/configure-pzserver.sh
+++ b/scrolls/lgsm/.build/versions/pzserver/data/configure-pzserver.sh
@@ -1,0 +1,19 @@
+set -eu
+
+cfg_dir="lgsm/config-lgsm/pzserver"
+cfg_file="${cfg_dir}/pzserver.cfg"
+mkdir -p "${cfg_dir}"
+
+main_port="${DRUID_PORT_MAIN_1:-16261}"
+udp_port="${DRUID_PORT_MAIN2_1:-16262}"
+admin_password="${PZ_ADMIN_PASSWORD:-}"
+
+if [ -z "${admin_password}" ]; then
+	admin_password="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+fi
+
+cat > "${cfg_file}" <<EOF
+startparameters="-servername \${selfname} -adminpassword ${admin_password} -port ${main_port} -udpport ${udp_port}"
+EOF
+
+chmod 600 "${cfg_file}"

--- a/scrolls/lgsm/.build/versions/pzserver/data/lgsm/config-lgsm/pzserver/pzserver.cfg.scroll_template
+++ b/scrolls/lgsm/.build/versions/pzserver/data/lgsm/config-lgsm/pzserver/pzserver.cfg.scroll_template
@@ -1,1 +1,0 @@
-startparameters="-servername ${selfname} -adminpassword {{ randAlphaNum 20  }} -port {{ env "DRUID_PORT_MAIN_1" | default "16261" }} -udpport {{ env "DRUID_PORT_MAIN2_1" | default "16262" }}"

--- a/scrolls/lgsm/pzserver/data/configure-pzserver.sh
+++ b/scrolls/lgsm/pzserver/data/configure-pzserver.sh
@@ -1,0 +1,19 @@
+set -eu
+
+cfg_dir="lgsm/config-lgsm/pzserver"
+cfg_file="${cfg_dir}/pzserver.cfg"
+mkdir -p "${cfg_dir}"
+
+main_port="${DRUID_PORT_MAIN_1:-16261}"
+udp_port="${DRUID_PORT_MAIN2_1:-16262}"
+admin_password="${PZ_ADMIN_PASSWORD:-}"
+
+if [ -z "${admin_password}" ]; then
+	admin_password="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+fi
+
+cat > "${cfg_file}" <<EOF
+startparameters="-servername \${selfname} -adminpassword ${admin_password} -port ${main_port} -udpport ${udp_port}"
+EOF
+
+chmod 600 "${cfg_file}"

--- a/scrolls/lgsm/pzserver/data/lgsm/config-lgsm/pzserver/pzserver.cfg.scroll_template
+++ b/scrolls/lgsm/pzserver/data/lgsm/config-lgsm/pzserver/pzserver.cfg.scroll_template
@@ -1,1 +1,0 @@
-startparameters="-servername ${selfname} -adminpassword {{ randAlphaNum 20  }} -port {{ env "DRUID_PORT_MAIN_1" | default "16261" }} -udpport {{ env "DRUID_PORT_MAIN2_1" | default "16262" }}"

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -53,7 +53,7 @@ commands:
       command:
       - sh
       - -lc
-      - ./pzserver start && exec ./pzserver console
+      - sh configure-pzserver.sh && ./pzserver start && exec ./pzserver console
   start:
     needs:
     - install
@@ -71,8 +71,9 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
-      - ./pzserver
-      - start
+      - sh
+      - -lc
+      - sh configure-pzserver.sh && ./pzserver start
   stop:
     run: always
     procedures:


### PR DESCRIPTION
## Summary
- configure Project Zomboid LGSM start parameters at runtime before start/console
- generate a random admin password when none is provided so PZ never blocks on the interactive prompt
- remove the inert pzserver.cfg.scroll_template path that LGSM was not loading

## Validation
- make build-tree
- ./scripts/validate_all_scrolls.sh
- git diff --check
- static guard: no stale pzserver template / interactive admin prompt references

## Production note
This fixes the observed prod failure where PZ reported STARTED but the Java process blocked on `Enter new administrator password` and never answered gamedig.