### PR TITLE
ci(prebuild): expose disk pressure

### DIFF
--- a/.github/workflows/prebuild-lsm.yml
+++ b/.github/workflows/prebuild-lsm.yml
@@ -67,9 +67,20 @@ jobs:
           registry: artifacts.druid.gg
           username: ${{ secrets.IMAGE_REGISTRY_USER }}
           password: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+      - name: Check disk before prebuild
+        run: |
+          set -euo pipefail
+          df -h / "$GITHUB_WORKSPACE" /var/lib/docker 2>/dev/null || true
+          docker system df || true
       - name: Prebuild and upload
         run: ./scripts/prebuild/prebuild.sh "${{ matrix.target }}"
         env:
           SCROLL_REGISTRY_HOST: ${{ secrets.SCROLL_REGISTRY_HOST }}
           SCROLL_REGISTRY_USER: ${{ secrets.SCROLL_REGISTRY_USER }}
           SCROLL_REGISTRY_PASSWORD: ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
+      - name: Check disk after prebuild
+        if: always()
+        run: |
+          set -euo pipefail
+          df -h / "$GITHUB_WORKSPACE" /var/lib/docker 2>/dev/null || true
+          docker system df || true

--- a/scripts/prebuild/main.go
+++ b/scripts/prebuild/main.go
@@ -109,7 +109,6 @@ func runSpec(spec prebuildSpec) error {
 	fmt.Printf("Prebuilding %s from %s\n", spec.Artifact, spec.Source)
 	for index, proc := range install.Procedures {
 		if err := runProcedure(root, spec, mounts, index, proc); err != nil {
-			_ = mounts.copyBack()
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary\n- avoid copying partial failed prebuild data back to the workspace\n- print disk/docker usage around each Steam prebuild target\n\n## Context\nCS2 prebuild failed because the runner ran out of disk while downloading App 730; this makes the failure cheaper and easier to diagnose.\n\n## Tests\n- go test ./scripts/prebuild\n- go run ./scripts/prebuild --targets all-steam --list-targets\n- ruby YAML parse for .github/workflows/prebuild-lsm.yml\n- git diff --check