### PR TITLE
fix(rust): raise idle traffic threshold

### DIFF
--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -26,9 +26,9 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.246
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       - name: query
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -56,11 +56,11 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       - name: query
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       - name: rustplus
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
   stop:
     procedures:
     - type: signal

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -26,9 +26,9 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.246
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       - name: query
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -56,11 +56,11 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       - name: query
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
       - name: rustplus
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 500kb/5m
   stop:
     procedures:
     - type: signal


### PR DESCRIPTION
## Summary
- raise Rust Vanilla/Oxide keepAliveTraffic from 10kb/5m to 500kb/5m
- observed idle Rust runtime stays around ~70kb/5m RX from background traffic, so 10kb/5m prevents coldstarter reengage

## Test Plan
- go test ./...
- git diff --check
- go run ../../scripts/validate-scrolls.go from scrolls/rust

Prod note: Fresh Rust Vanilla successfully coldstarted and answered A2S after #44, but did not idle-stop after the full 5m window because pod RX stayed above 10kb/5m with no intentional client traffic.