### PR TITLE
fix(rust): wake coldstarter on unknown packets

### DIFF
--- a/scrolls/rust/rust-oxide/latest/packet_handler/query.lua
+++ b/scrolls/rust/rust-oxide/latest/packet_handler/query.lua
@@ -178,6 +178,7 @@ function handle(ctx, data)
     end
 
     debug_print("Unknown Packet: " .. hex)
+    finish()
 
 end
 

--- a/scrolls/rust/rust-vanilla/latest/packet_handler/query.lua
+++ b/scrolls/rust/rust-vanilla/latest/packet_handler/query.lua
@@ -178,6 +178,7 @@ function handle(ctx, data)
     end
 
     debug_print("Unknown Packet: " .. hex)
+    finish()
 
 end
 


### PR DESCRIPTION
## Summary
- wake Rust Vanilla/Oxide coldstarter on valid Source-framed unknown packets
- keeps A2S info responses as idle listing responses

## Test Plan
- go test ./scripts/prebuild ./scripts/...
- go run ./scripts/validate-scrolls.go
- git diff --check