### PR TITLE
fix(cs2): include lgsm permission patch chunk

### DIFF
--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -18,6 +18,8 @@ chunks:
     path: postinstall.sh
   - name: postinstall-template
     path: postinstall.sh.scroll_template
+  - name: patch-lgsm-permissions
+    path: patch-lgsm-permissions.sh
   - name: serverfiles
     path: serverfiles
     chunks:


### PR DESCRIPTION
## Summary
- include patch-lgsm-permissions.sh in the CS2 artifact chunks
- fixes CS2 install step failing with missing patch helper after release

## Validation
- go run ./scripts/validate-scrolls.go
- git diff --check

DayZ intentionally skipped per current validation sweep.