### PR TITLE
fix(cs2): harden postinstall password generation

### DIFF
--- a/scrolls/lgsm/cs2server/data/postinstall.sh
+++ b/scrolls/lgsm/cs2server/data/postinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eu
 
 config_file="serverfiles/game/csgo/cfg/server.cfg"
 password_file=".druid-rcon-password"
@@ -9,7 +9,11 @@ if [ -n "${CS2_RCON_PASSWORD:-}" ]; then
 elif [ -f "$password_file" ]; then
   rcon_password="$(cat "$password_file")"
 else
-  rcon_password="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 50)"
+  rcon_password="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 50 || true)"
+  if [ "${#rcon_password}" -ne 50 ]; then
+    echo "failed to generate rcon password" >&2
+    exit 1
+  fi
   printf '%s\n' "$rcon_password" > "$password_file"
   chmod 600 "$password_file"
 fi


### PR DESCRIPTION
## Summary
- make CS2 postinstall password generation portable and deterministic in length
- avoid pipefail/SIGPIPE from tr | head causing silent install-5 failure

## Validation
- local postinstall smoke test creates a 50-char RCON password and writes server.cfg
- go run ./scripts/validate-scrolls.go
- git diff --check

## Prod finding
Fresh CS2 deployment 80e5f9f7-598f-405c-b308-c97de67bc163 reached install-5 with the concrete script but failed with empty logs, consistent with shell pipefail abort during password generation.

DayZ remains skipped per current sweep.