### PR TITLE
fix: tune lgsm keepalive thresholds

### DIFF
--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -18,6 +18,7 @@ ports:
 {{- end }}
 {{- end }}
 commands:
+{{- $keepAliveTraffic := or .Vars.keep_alive_traffic "10kb/5m" }}
   console:
     needs:
     - start
@@ -28,11 +29,11 @@ commands:
       expectedPorts:
 {{- if .Vars.lua_query_game_name }}
       - name: {{ $queryPort }}
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: {{ $keepAliveTraffic }}
 {{- end }}
 {{- if and .Vars.main_port_protocol (ne $queryPort "main") }}
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: {{ $keepAliveTraffic }}
 {{- end }}
 {{- if .Vars.rcon_port }}
       - name: rcon
@@ -79,11 +80,11 @@ commands:
       expectedPorts:
 {{- if .Vars.lua_query_game_name }}
       - name: {{ $queryPort }}
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: {{ $keepAliveTraffic }}
 {{- end }}
 {{- if and .Vars.main_port_protocol (ne $queryPort "main") }}
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: {{ $keepAliveTraffic }}
 {{- end }}
       mounts:
       - path: "/server"

--- a/scrolls/lgsm/.build/vars.json
+++ b/scrolls/lgsm/.build/vars.json
@@ -28,6 +28,7 @@
   "pwserver": {
     "port": "main=8211/udp;rcon=25575",
     "main_port_protocol": "udp",
+    "keep_alive_traffic": "1mb/5m",
     "lua_steam_app_id": "1623730",
     "dependencies": "bc;binutils;bzip2;cpio;file;jq;pkgsi686Linux.gcc;netcat;pigz;python3;tmux;unzip;util-linux;moreutils;iproute2"
   },
@@ -96,6 +97,7 @@
   },
   "pzserver": {
     "port": "main=16261/udp;main2=16262/udp;maintcp=16261",
+    "keep_alive_traffic": "1mb/5m",
     "lua_query_game_name": "Project Zomboid",
     "lua_query_folder": "zomboid",
     "lua_query_map": "server idle",

--- a/scrolls/lgsm/.build/versions/arkserver/chunks.yaml
+++ b/scrolls/lgsm/.build/versions/arkserver/chunks.yaml
@@ -7,6 +7,8 @@ chunks:
     path: linuxgsm.sh
   - name: lgsm
     path: lgsm
+  - name: patch-lgsm-permissions
+    path: patch-lgsm-permissions.sh
   - name: serverfiles
     path: serverfiles
     chunks:

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -12,6 +12,8 @@ chunks:
     path: linuxgsm.sh
   - name: lgsm
     path: lgsm
+  - name: patch-lgsm-permissions
+    path: patch-lgsm-permissions.sh
   - name: serverfiles
     path: serverfiles
     chunks:

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -21,7 +21,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.248
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -35,7 +35,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -24,7 +24,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.248
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -45,7 +45,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       mounts:
       - path: "/server"
       working_dir: "/server"


### PR DESCRIPTION
## Summary
- allow LGSM scrolls to override keepAliveTraffic per game
- raise Palworld and Project Zomboid keepalive thresholds to 1mb/5m
- regenerate affected scroll YAML files

## Validation
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh
- git diff --check

## Prod observation
- Palworld idle/background RX was about 80kb/5m with no real player traffic
- Project Zomboid idle/background RX was about 60kb/5m with no real player traffic
