### PR TITLE
fix: use one 7 days coldstarter listener

### DIFF
--- a/scrolls/lgsm/.build/vars.json
+++ b/scrolls/lgsm/.build/vars.json
@@ -48,10 +48,12 @@
   },
   "sdtdserver": {
     "port": "query=26900/udp;main=26900/udp;main2=26902/udp;maintcp=26900",
+    "lua_query_port": "main",
     "lua_query_game_name": "7 Days To Die",
     "lua_query_folder": "7DTD",
     "lua_query_map": "server idle",
     "lua_query_servername": "Druid.gg Server (idle) - join to start",
+    "lua_query_start_on_unknown_packet": "yes",
     "main_port_protocol": "udp",
     "lua_steam_app_id": "251570",
     "dependencies": "bc;binutils;bzip2;cpio;file;jq;pkgsi686Linux.gcc;netcat;pigz;python3;tmux;unzip;util-linux;moreutils;iproute2"

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -27,8 +27,6 @@ commands:
     - id: coldstart
       image: artifacts.druid.gg/druid-team/druid:v0.1.248
       expectedPorts:
-      - name: query
-        keepAliveTraffic: 10kb/5m
       - name: main
         keepAliveTraffic: 10kb/5m
       mounts:
@@ -37,21 +35,19 @@ commands:
       working_dir: "/runtime"
       env:
         DRUID_ROOT: "/runtime"
-        DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_PORT_MAIN_COLDSTARTER: "packet_handler/query.lua"
         DRUID_COLDSTARTER_VAR_GAME_NAME: "7 Days To Die"
         DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "7DTD"
         DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"
         DRUID_COLDSTARTER_VAR_MAP_NAME: "server idle"
         DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
+        DRUID_COLDSTARTER_VAR_START_ON_UNKNOWN_PACKET: "yes"
         DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "251570"
-        DRUID_PORT_MAIN_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start
       image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
       expectedPorts:
-      - name: query
-        keepAliveTraffic: 10kb/5m
       - name: main
         keepAliveTraffic: 10kb/5m
       mounts:


### PR DESCRIPTION
## Summary
- bind the 7 Days coldstarter Lua handler to the main UDP port instead of trying to run separate query/main handlers on the same internal port
- enable unknown-packet wake for the 7 Days coldstarter
- regenerate the sdtdserver scroll from LGSM vars

## Validation
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh
- git diff --check