### PR TITLE
chore: bump scroll runtime to v0.1.249

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
       SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
       SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
-      DRUID_CLI_VERSION: v0.1.248
+      DRUID_CLI_VERSION: v0.1.249
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/prebuild-lsm.yml
+++ b/.github/workflows/prebuild-lsm.yml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.resolve-targets.outputs.targets) }}
     env:
-      DRUID_CLI_VERSION: v0.1.248
-      DRUID_RUNTIME_IMAGE: artifacts.druid.gg/druid-team/druid:v0.1.248
-      DRUID_STEAM_RUNTIME_IMAGE: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      DRUID_CLI_VERSION: v0.1.249
+      DRUID_RUNTIME_IMAGE: artifacts.druid.gg/druid-team/druid:v0.1.249
+      DRUID_STEAM_RUNTIME_IMAGE: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       PREBUILD_DOCKER_PLATFORM: linux/amd64
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
       SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
       SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
-      DRUID_CLI_VERSION: v0.1.248
+      DRUID_CLI_VERSION: v0.1.249
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/generate-scrolls.go
+++ b/generate-scrolls.go
@@ -103,11 +103,11 @@ func main() {
 	}
 	coldstarterImage := os.Getenv("DRUID_COLDSTARTER_IMAGE")
 	if coldstarterImage == "" {
-		coldstarterImage = "artifacts.druid.gg/druid-team/druid:v0.1.248"
+		coldstarterImage = "artifacts.druid.gg/druid-team/druid:v0.1.249"
 	}
 	steamImage := os.Getenv("DRUID_STEAM_RUNTIME_IMAGE")
 	if steamImage == "" {
-		steamImage = "artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd"
+		steamImage = "artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd"
 	}
 
 	//iterate through artifacts and generate scroll.yaml files

--- a/scripts/prebuild/main.go
+++ b/scripts/prebuild/main.go
@@ -638,7 +638,7 @@ func selectSpecs(raw string) ([]prebuildSpec, error) {
 }
 
 func allSpecs() []prebuildSpec {
-	steamImage := getenv("DRUID_STEAM_RUNTIME_IMAGE", "artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd")
+	steamImage := getenv("DRUID_STEAM_RUNTIME_IMAGE", "artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd")
 	specs := []prebuildSpec{
 		{Target: "pwserver", Artifact: "artifacts.druid.gg/druid-team/scroll-lgsm:pwserver-prebuild", Source: "./scrolls/lgsm/pwserver", Image: steamImage, Ports: []string{"main=8211/udp", "rcon=25575"}, MinDisk: "7Gi", MinRAM: "2Gi", MinCPU: "0.5", Category: "palworld", Smart: true, PackMeta: true},
 		{Target: "arkserver", Artifact: "artifacts.druid.gg/druid-team/scroll-lgsm:arkserver-prebuild", Source: "./scrolls/lgsm/arkserver", Image: steamImage, Ports: []string{"main=7777/udp", "query=27015/udp", "rcon=27020"}, MinDisk: "25Gi", MinRAM: "7Gi", MinCPU: "0.5", Category: "ark", Smart: true, PackMeta: true},

--- a/scripts/prebuild/prebuild.sh
+++ b/scripts/prebuild/prebuild.sh
@@ -7,8 +7,8 @@ targets="${1:-all-steam}"
 : "${SCROLL_REGISTRY_USER:?SCROLL_REGISTRY_USER is required}"
 : "${SCROLL_REGISTRY_PASSWORD:?SCROLL_REGISTRY_PASSWORD is required}"
 
-export DRUID_RUNTIME_IMAGE="${DRUID_RUNTIME_IMAGE:-artifacts.druid.gg/druid-team/druid:v0.1.248}"
-export DRUID_STEAM_RUNTIME_IMAGE="${DRUID_STEAM_RUNTIME_IMAGE:-artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd}"
+export DRUID_RUNTIME_IMAGE="${DRUID_RUNTIME_IMAGE:-artifacts.druid.gg/druid-team/druid:v0.1.249}"
+export DRUID_STEAM_RUNTIME_IMAGE="${DRUID_STEAM_RUNTIME_IMAGE:-artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd}"
 export PREBUILD_DOCKER_PLATFORM="${PREBUILD_DOCKER_PLATFORM:-linux/amd64}"
 
 echo "Targets: ${targets}"

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -10,7 +10,7 @@ registry_host="${registry_host%%/*}"
 
 namespace="${SCROLL_REGISTRY_PR_NAMESPACE:-druid-team-experimental}"
 runtime_namespace="${SCROLL_REGISTRY_RUNTIME_NAMESPACE:-druid-team}"
-runtime_image="${DRUID_SCROLL_RUNTIME_IMAGE:-${registry_host}/${runtime_namespace}/druid:v0.1.248}"
+runtime_image="${DRUID_SCROLL_RUNTIME_IMAGE:-${registry_host}/${runtime_namespace}/druid:v0.1.249}"
 roots="${SCROLL_PR_ROOTS:-}"
 
 yaml_value() {

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -63,7 +63,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: query
         keepAliveTraffic: 1mb/5m
@@ -88,7 +88,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: query
         keepAliveTraffic: 1mb/5m
@@ -107,14 +107,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./arkserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -124,7 +124,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -133,14 +133,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -150,35 +150,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - arkserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -73,7 +73,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -94,7 +94,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -111,14 +111,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./cs2server
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -128,7 +128,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -137,14 +137,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -154,42 +154,42 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - cs2server
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./cs2server
       - auto-install
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -25,7 +25,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -46,7 +46,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -63,14 +63,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./csgoserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -80,7 +80,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -89,14 +89,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -106,35 +106,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - csgoserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -22,7 +22,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m
@@ -36,7 +36,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m
@@ -53,14 +53,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./dayzserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -70,7 +70,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -79,14 +79,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -96,35 +96,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - dayzserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -25,7 +25,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -49,7 +49,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -66,14 +66,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./gmodserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -83,7 +83,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -92,14 +92,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -109,35 +109,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - gmodserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -18,7 +18,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -32,7 +32,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -49,14 +49,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./pwserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -66,7 +66,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -75,14 +75,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -92,35 +92,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - pwserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -21,7 +21,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -42,7 +42,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -59,14 +59,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./pzserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -77,7 +77,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -86,14 +86,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -103,35 +103,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - pzserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -25,7 +25,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -46,7 +46,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -63,14 +63,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./sdtdserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -80,7 +80,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -89,14 +89,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -106,35 +106,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - sdtdserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -18,7 +18,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -39,7 +39,7 @@ commands:
       command:
       - druid-coldstarter
     - id: start
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
@@ -56,14 +56,14 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./untserver
       - update
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -73,7 +73,7 @@ commands:
   stop:
     run: always
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -82,14 +82,14 @@ commands:
       - stop
   restart:
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Restarting server...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -99,35 +99,35 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - install-lgsm.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - ./linuxgsm.sh
       - untserver
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m
@@ -31,7 +31,7 @@ commands:
         DRUID_PORT_WEBPANEL_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -53,7 +53,7 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -63,7 +63,7 @@ commands:
       - "-O"
       - Cuberite.tar.gz
       - https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -16,7 +16,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 10kb/5m

--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -23,7 +23,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 500kb/5m
@@ -46,7 +46,7 @@ commands:
         DRUID_COLDSTARTER_VAR_GAME_KEYWORDS: "mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420"
       command:
       - druid-coldstarter
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -70,7 +70,7 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -83,7 +83,7 @@ commands:
       - "+app_update"
       - '258550'
       - "+quit"
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -92,7 +92,7 @@ commands:
       - "-O"
       - oxide.zip
       - https://umod.org/games/rust/download/develop
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -102,7 +102,7 @@ commands:
       - oxide.zip
       - "-d"
       - "/server"
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -23,7 +23,7 @@ commands:
     run: restart
     procedures:
     - id: coldstart
-      image: artifacts.druid.gg/druid-team/druid:v0.1.248
+      image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
         keepAliveTraffic: 500kb/5m
@@ -46,7 +46,7 @@ commands:
         DRUID_COLDSTARTER_VAR_GAME_KEYWORDS: "mp0,cp0,ptrak,qp0,$r?,v2592,born0,gmrust,cs1337420"
       command:
       - druid-coldstarter
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -70,7 +70,7 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.248-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"


### PR DESCRIPTION
## Summary
- bump generated scroll runtime image references to druid v0.1.249
- bump Steam/LGSM runtime image references to v0.1.249-steamcmd
- bump CI/prebuild druid CLI defaults to v0.1.249

## Validation
- make build-tree
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh
- rg "v0\.1\.248|highcard/druid|stable-nix|latest-nix|latest-nix-steamcmd|stable-nix-steamcmd" . (no matches)
- git diff --check
- docker run --rm --platform linux/amd64 --entrypoint sh artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd -lc 'druid version && command -v expect && command -v xmllint && command -v telnet'