### PR TITLE
Fix pzserver secondary expected ports

### DIFF
--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -35,6 +35,17 @@ commands:
       - name: main
         keepAliveTraffic: {{ $keepAliveTraffic }}
 {{- end }}
+{{- if .Vars.extra_expected_keepalive_ports }}
+{{- range split ";" .Vars.extra_expected_keepalive_ports }}
+      - name: {{ . }}
+        keepAliveTraffic: {{ $keepAliveTraffic }}
+{{- end }}
+{{- end }}
+{{- if .Vars.extra_expected_ports }}
+{{- range split ";" .Vars.extra_expected_ports }}
+      - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- if .Vars.rcon_port }}
       - name: rcon
 {{- end }}
@@ -73,6 +84,16 @@ commands:
 {{- if .Vars.rcon_port }}
         DRUID_PORT_RCON_COLDSTARTER: "generic"
 {{- end }}
+{{- if .Vars.extra_expected_keepalive_ports }}
+{{- range split ";" .Vars.extra_expected_keepalive_ports }}
+        DRUID_PORT_{{ upper . }}_COLDSTARTER: "generic"
+{{- end }}
+{{- end }}
+{{- if .Vars.extra_expected_ports }}
+{{- range split ";" .Vars.extra_expected_ports }}
+        DRUID_PORT_{{ upper . }}_COLDSTARTER: "generic"
+{{- end }}
+{{- end }}
       command:
       - druid-coldstarter
     - id: start
@@ -85,6 +106,17 @@ commands:
 {{- if and .Vars.main_port_protocol (ne $queryPort "main") }}
       - name: main
         keepAliveTraffic: {{ $keepAliveTraffic }}
+{{- end }}
+{{- if .Vars.extra_expected_keepalive_ports }}
+{{- range split ";" .Vars.extra_expected_keepalive_ports }}
+      - name: {{ . }}
+        keepAliveTraffic: {{ $keepAliveTraffic }}
+{{- end }}
+{{- end }}
+{{- if .Vars.extra_expected_ports }}
+{{- range split ";" .Vars.extra_expected_ports }}
+      - name: {{ . }}
+{{- end }}
 {{- end }}
       mounts:
       - path: "/server"

--- a/scrolls/lgsm/.build/vars.json
+++ b/scrolls/lgsm/.build/vars.json
@@ -107,6 +107,8 @@
     "lua_query_servername": "Druid.gg Server (idle) - join to start",
     "lua_query_port": "main",
     "lua_query_start_on_unknown_packet": "yes",
+    "extra_expected_keepalive_ports": "main2",
+    "extra_expected_ports": "maintcp",
     "lua_steam_app_id": "108600",
     "dependencies": "bc;binutils;bzip2;cpio;file;jq;pkgsi686Linux.gcc;netcat;pigz;python3;tmux;unzip;util-linux;moreutils;iproute2"
   }

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -50,6 +50,9 @@ commands:
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
+      - name: main2
+        keepAliveTraffic: 1mb/5m
+      - name: maintcp
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -64,6 +67,8 @@ commands:
         DRUID_COLDSTARTER_VAR_SERVER_LIST_NAME: "Druid.gg Server (idle) - join to start"
         DRUID_COLDSTARTER_VAR_START_ON_UNKNOWN_PACKET: "yes"
         DRUID_COLDSTARTER_VAR_STEAM_APP_ID: "108600"
+        DRUID_PORT_MAIN2_COLDSTARTER: "generic"
+        DRUID_PORT_MAINTCP_COLDSTARTER: "generic"
       command:
       - druid-coldstarter
     - id: start
@@ -71,6 +76,9 @@ commands:
       expectedPorts:
       - name: main
         keepAliveTraffic: 1mb/5m
+      - name: main2
+        keepAliveTraffic: 1mb/5m
+      - name: maintcp
       mounts:
       - path: "/server"
       working_dir: "/server"


### PR DESCRIPTION
## Summary
- add generator support for extra expected LGSM ports
- expose pzserver main2/maintcp in coldstart and runtime procedures

## Validation
- make build-tree
- go test ./scripts/prebuild ./scripts/validate-release-workflow
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh