### PR TITLE
Fix LGSM install reruns

### DIFF
--- a/scrolls/lgsm/.build/data/install-lgsm.sh
+++ b/scrolls/lgsm/.build/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/arkserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/arkserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/cs2server/data/install-lgsm.sh
+++ b/scrolls/lgsm/cs2server/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/csgoserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/csgoserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/dayzserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/dayzserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/gmodserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/gmodserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/pwserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/pwserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/pzserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/pzserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/sdtdserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/sdtdserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master

--- a/scrolls/lgsm/untserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/untserver/data/install-lgsm.sh
@@ -1,15 +1,15 @@
 set -e
 
+rm -rf LinuxGSM-master
 wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
 tar -xzf lgsm.tar.gz
 
-#recreate lgsm dir
-#rm -rf lgsm
 mkdir -p lgsm
 
-
+rm -f linuxgsm.sh
+rm -rf lgsm/modules
 mv LinuxGSM-master/linuxgsm.sh .
-mv LinuxGSM-master/lgsm/modules/ lgsm
+mv LinuxGSM-master/lgsm/modules lgsm/modules
 chmod -R +x lgsm/modules/
 
 rm -rf LinuxGSM-master


### PR DESCRIPTION
## Summary
- make LGSM install refresh safe to rerun against persistent server directories
- replace stale linuxgsm.sh and lgsm/modules before moving fresh LinuxGSM files
- regenerate LGSM scroll outputs from the existing build source

## Test Plan
- env GOCACHE=/private/tmp/druid-go-cache make build-tree
- env GOCACHE=/private/tmp/druid-go-cache go test ./scripts/prebuild ./scripts/validate-release-workflow
- env GOCACHE=/private/tmp/druid-go-cache go run ./scripts/validate-scrolls.go
- env GOCACHE=/private/tmp/druid-go-cache ./scripts/validate_all_scrolls.sh