### PR TITLE
Fix Rust coldstart rustplus routing

### DIFF
--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -29,6 +29,8 @@ commands:
         keepAliveTraffic: 500kb/5m
       - name: query
         keepAliveTraffic: 500kb/5m
+      - name: rustplus
+        keepAliveTraffic: 500kb/5m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -37,6 +39,7 @@ commands:
         DRUID_ROOT: "/runtime"
         DRUID_PORT_MAIN_COLDSTARTER: "generic"
         DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_PORT_RUSTPLUS_COLDSTARTER: "generic"
         DRUID_COLDSTARTER_VAR_GAME_NAME: "Rust"
         DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "rust"
         DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -29,6 +29,8 @@ commands:
         keepAliveTraffic: 500kb/5m
       - name: query
         keepAliveTraffic: 500kb/5m
+      - name: rustplus
+        keepAliveTraffic: 500kb/5m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -37,6 +39,7 @@ commands:
         DRUID_ROOT: "/runtime"
         DRUID_PORT_MAIN_COLDSTARTER: "generic"
         DRUID_PORT_QUERY_COLDSTARTER: "packet_handler/query.lua"
+        DRUID_PORT_RUSTPLUS_COLDSTARTER: "generic"
         DRUID_COLDSTARTER_VAR_GAME_NAME: "Rust"
         DRUID_COLDSTARTER_VAR_GAME_STEAM_FOLDER: "rust"
         DRUID_COLDSTARTER_VAR_GAME_STEAM_ID: "0"


### PR DESCRIPTION
## Summary
- expose rustplus in the Rust coldstart expectedPorts
- map rustplus to the generic coldstarter listener so TCP routing has ready idle endpoints

## Test Plan
- env GOCACHE=/private/tmp/druid-go-cache make build-tree
- env GOCACHE=/private/tmp/druid-go-cache go test ./scripts/prebuild ./scripts/validate-release-workflow
- env GOCACHE=/private/tmp/druid-go-cache go run ./scripts/validate-scrolls.go
- env GOCACHE=/private/tmp/druid-go-cache ./scripts/validate_all_scrolls.sh