### PR TITLE
fix: keep minecraft coldstarters idle

### DIFF
--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -19,7 +19,6 @@ commands:
       image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -19,7 +19,6 @@ commands:
       image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -19,7 +19,6 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
       - name: rcon
       mounts:
       - path: "/runtime"


### PR DESCRIPTION
## Summary
- remove keepAliveTraffic from PaperMC coldstarter expected ports
- remove keepAliveTraffic from Spigot coldstarter expected ports
- regenerate affected Minecraft scrolls from templates

## Tests
- GOCACHE=/private/tmp/druid-go-cache make build-tree
- GOCACHE=/private/tmp/druid-go-cache go run ./scripts/validate-scrolls.go
- GOCACHE=/private/tmp/druid-go-cache go test ./scripts/prebuild
- GOCACHE=/private/tmp/druid-go-cache ./scripts/validate_all_scrolls.sh
- GOCACHE=/private/tmp/druid-go-cache go run ./scripts/validate-release-workflow
- GOCACHE=/private/tmp/druid-go-cache go test ./scripts/validate-release-workflow
- git diff --check