### PR TITLE
fix: raise cuberite keepalive threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ On Kubernetes runtimes, `keepAliveTraffic` is an enforcement rule for job proced
 
 For Minecraft coldstarter scrolls, attach `keepAliveTraffic` to the real runtime procedure's `main` expected port. Do not attach it to the coldstarter procedure; the standby listener must remain available while idle.
 
-Minecraft scrolls should use `10kb/5m` on the real runtime `main` port. Server-list pings are small and should not keep a runtime warm; active clients generate recurring keep-alive/play traffic and should keep the runtime alive.
+Minecraft scrolls should use `1mb/5m` on the real runtime `main` port. Server-list pings are small and should not keep a runtime warm; active clients generate recurring keep-alive/play traffic and should keep the runtime alive.

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: webpanel
       mounts:
       - path: "/runtime"
@@ -41,9 +41,9 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: webpanel
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
   stop:
     procedures:
     - type: signal


### PR DESCRIPTION
## Summary
- Raise Cuberite Minecraft keepAliveTraffic threshold to 1mb/5m
- Keep README guidance in sync

## Test plan
- make build-tree
- go test ./scripts/prebuild
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh
- go run ./scripts/validate-release-workflow