### PR TITLE
fix: raise minecraft keepalive thresholds

### DIFF
--- a/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
@@ -19,7 +19,7 @@ commands:
       image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:16-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:16-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:16-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -19,7 +19,7 @@ commands:
       image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 1mb/5m
       - name: rcon
       mounts:
       - path: "/server"


### PR DESCRIPTION
## Summary
- Raise Minecraft keepAliveTraffic thresholds from 10kb/5m to 1mb/5m across generated scrolls
- Update source templates so make build-tree preserves the thresholds

## Test plan
- make build-tree
- go test ./scripts/prebuild
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh
- go run ./scripts/validate-release-workflow