### PR TITLE
Extend scroll idle timeout to 30 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ On Kubernetes runtimes, `keepAliveTraffic` is an enforcement rule for job proced
 
 For Minecraft coldstarter scrolls, attach `keepAliveTraffic` to the real runtime procedure's `main` expected port. Do not attach it to the coldstarter procedure; the standby listener must remain available while idle.
 
-Minecraft scrolls should use `10kb/5m` on the real runtime `main` port. Server-list pings are small and should not keep a runtime warm; active clients generate recurring keep-alive/play traffic and should keep the runtime alive.
+Minecraft scrolls should use `10kb/30m` on the real runtime `main` port. Server-list pings are small and should not keep a runtime warm; active clients generate recurring keep-alive/play traffic and should keep the runtime alive.

--- a/scrolls/hytale/hytale-druid-gg/scroll.yaml
+++ b/scrolls/hytale/hytale-druid-gg/scroll.yaml
@@ -69,6 +69,6 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
     run: restart
 serve: start

--- a/scrolls/hytale/hytale-standalone/scroll.yaml
+++ b/scrolls/hytale/hytale-standalone/scroll.yaml
@@ -54,6 +54,6 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
     run: restart
 serve: start

--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -18,7 +18,7 @@ ports:
 {{- end }}
 {{- end }}
 commands:
-{{- $keepAliveTraffic := or .Vars.keep_alive_traffic "1mb/5m" }}
+{{- $keepAliveTraffic := or .Vars.keep_alive_traffic "1mb/30m" }}
   console:
     needs:
     - start

--- a/scrolls/lgsm/.build/vars.json
+++ b/scrolls/lgsm/.build/vars.json
@@ -28,7 +28,7 @@
   "pwserver": {
     "port": "main=8211/udp;rcon=25575",
     "main_port_protocol": "udp",
-    "keep_alive_traffic": "1mb/5m",
+    "keep_alive_traffic": "1mb/30m",
     "lua_steam_app_id": "1623730",
     "dependencies": "bc;binutils;bzip2;cpio;file;jq;pkgsi686Linux.gcc;netcat;pigz;python3;tmux;unzip;util-linux;moreutils;iproute2"
   },
@@ -61,7 +61,7 @@
   "dayzserver": {
     "port": "main=2302/udp;battle-eye=2304/udp;query=27016/udp",
     "main_port_protocol": "udp",
-    "keep_alive_traffic": "10kb/5m",
+    "keep_alive_traffic": "10kb/30m",
     "lua_steam_app_id": "221100",
     "dependencies": "bc;binutils;bzip2;cpio;file;jq;pkgsi686Linux.gcc;netcat;pigz;python3;tmux;unzip;util-linux;moreutils;iproute2"
   },
@@ -100,7 +100,7 @@
   },
   "pzserver": {
     "port": "main=16261/udp;main2=16262/udp;maintcp=16261",
-    "keep_alive_traffic": "1mb/5m",
+    "keep_alive_traffic": "1mb/30m",
     "lua_query_game_name": "Project Zomboid",
     "lua_query_folder": "zomboid",
     "lua_query_map": "server idle",

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -66,9 +66,9 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: query
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -91,9 +91,9 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: query
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -76,7 +76,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -97,7 +97,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -28,7 +28,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -49,7 +49,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -25,7 +25,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -39,7 +39,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -28,7 +28,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -52,7 +52,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -21,7 +21,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -35,7 +35,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -49,9 +49,9 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: main2
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: maintcp
       mounts:
       - path: "/runtime"
@@ -75,9 +75,9 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: main2
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       - name: maintcp
       mounts:
       - path: "/server"

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -28,7 +28,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -49,7 +49,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -21,7 +21,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -42,7 +42,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249-steamcmd
       expectedPorts:
       - name: main
-        keepAliveTraffic: 1mb/5m
+        keepAliveTraffic: 1mb/30m
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: webpanel
       mounts:
       - path: "/runtime"
@@ -41,9 +41,9 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: webpanel
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
   stop:
     procedures:
     - type: signal

--- a/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
@@ -19,7 +19,7 @@ commands:
       image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:16-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -42,7 +42,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:16-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:16-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -19,7 +19,7 @@ commands:
       image: {{ .ColdstarterImage }}
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:17-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -19,7 +19,7 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/runtime"
@@ -35,7 +35,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -34,7 +34,7 @@ commands:
       image: eclipse-temurin:21-jre
       expectedPorts:
       - name: main
-        keepAliveTraffic: 10kb/5m
+        keepAliveTraffic: 10kb/30m
       - name: rcon
       mounts:
       - path: "/server"

--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -26,11 +26,11 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: query
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: rustplus
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -59,11 +59,11 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: query
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: rustplus
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
   stop:
     procedures:
     - type: signal

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -26,11 +26,11 @@ commands:
       image: artifacts.druid.gg/druid-team/druid:v0.1.249
       expectedPorts:
       - name: main
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: query
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: rustplus
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       mounts:
       - path: "/runtime"
         sub_path: "."
@@ -59,11 +59,11 @@ commands:
       id: start
       expectedPorts:
       - name: main
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: query
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
       - name: rustplus
-        keepAliveTraffic: 500kb/5m
+        keepAliveTraffic: 500kb/30m
   stop:
     procedures:
     - type: signal


### PR DESCRIPTION
## Summary
- change all scroll keepAliveTraffic windows from 5m to 30m while preserving traffic thresholds
- update generated scroll YAML plus build templates/vars so make build-tree keeps the new window
- update README guidance for Minecraft keepAliveTraffic

## Validation
- make build-tree
- go test ./scripts/prebuild
- go test ./scripts/validate-release-workflow
- go run ./scripts/validate-scrolls.go
- ./scripts/validate_all_scrolls.sh
- git diff --check