### PR TITLE
feat(scrolls): expose download progress across catalog

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       SCROLL_REGISTRY_API_KEY: ${{ secrets.SCROLL_REGISTRY_API_KEY }}
       SCROLL_REGISTRY_API_SECRET: ${{ secrets.SCROLL_REGISTRY_API_SECRET }}
       SCROLL_REGISTRY_BUCKET: ${{ secrets.SCROLL_REGISTRY_BUCKET_STAGING }}
-      DRUID_CLI_VERSION: v0.1.257
+      DRUID_CLI_VERSION: v0.1.258
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       SCROLL_REGISTRY_HOST: ${{ secrets.SCROLL_REGISTRY_HOST }}
       SCROLL_REGISTRY_USER: ${{ secrets.SCROLL_REGISTRY_USER }}
       SCROLL_REGISTRY_PASSWORD: ${{ secrets.SCROLL_REGISTRY_PASSWORD }}
-      DRUID_CLI_VERSION: v0.1.257
+      DRUID_CLI_VERSION: v0.1.258
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/generate-scrolls.go
+++ b/generate-scrolls.go
@@ -105,11 +105,11 @@ func main() {
 	}
 	progressImage := os.Getenv("DRUID_PROGRESS_RUNTIME_IMAGE")
 	if progressImage == "" {
-		progressImage = "artifacts.druid.gg/druid-team/druid:stable"
+		progressImage = "artifacts.druid.gg/druid-team/druid:v0.1.258"
 	}
 	progressSteamImage := os.Getenv("DRUID_PROGRESS_STEAM_RUNTIME_IMAGE")
 	if progressSteamImage == "" {
-		progressSteamImage = "artifacts.druid.gg/druid-team/druid:stable-steamcmd"
+		progressSteamImage = "artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd"
 	}
 	coldstarterImage := os.Getenv("DRUID_COLDSTARTER_IMAGE")
 	if coldstarterImage == "" {

--- a/generate-scrolls.go
+++ b/generate-scrolls.go
@@ -20,6 +20,8 @@ type TemplateVars struct {
 	Artifact           string
 	Version            string
 	VersionEscaped     string
+	ProgressImage      string
+	ProgressSteamImage string
 	ColdstarterImage   string
 	SteamImage         string
 	Artifacts          map[string]string
@@ -101,6 +103,14 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	progressImage := os.Getenv("DRUID_PROGRESS_RUNTIME_IMAGE")
+	if progressImage == "" {
+		progressImage = "artifacts.druid.gg/druid-team/druid:stable"
+	}
+	progressSteamImage := os.Getenv("DRUID_PROGRESS_STEAM_RUNTIME_IMAGE")
+	if progressSteamImage == "" {
+		progressSteamImage = "artifacts.druid.gg/druid-team/druid:stable-steamcmd"
+	}
 	coldstarterImage := os.Getenv("DRUID_COLDSTARTER_IMAGE")
 	if coldstarterImage == "" {
 		coldstarterImage = "artifacts.druid.gg/druid-team/druid:v0.1.256"
@@ -117,6 +127,8 @@ func main() {
 		templateVars.Artifact = artifact
 		templateVars.Version = version
 		templateVars.VersionEscaped = strings.Replace(version, ".", "-", -1)
+		templateVars.ProgressImage = progressImage
+		templateVars.ProgressSteamImage = progressSteamImage
 		templateVars.ColdstarterImage = coldstarterImage
 		templateVars.SteamImage = steamImage
 		templateVars.Artifacts = GetArtifactsAbove(version, artifacts, true)

--- a/generate-scrolls_test.go
+++ b/generate-scrolls_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -106,7 +108,7 @@ func TestReleasedScrollsHaveTruthfulInstallProgress(t *testing.T) {
 					t,
 					scroll,
 					[]string{"sh", "install-lgsm.sh"},
-					"artifacts.druid.gg/druid-team/druid:stable-steamcmd",
+					"artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd",
 				)
 			case strings.Contains(path, "/rust/"):
 				requireGeneratedCommandPrefix(t, commands, "druid", "progress", "steamcmd", "--")
@@ -133,12 +135,99 @@ func TestReleasedScrollsHaveTruthfulInstallProgress(t *testing.T) {
 					t,
 					scroll,
 					[]string{"sh", "install.sh"},
-					"artifacts.druid.gg/druid-team/druid:stable",
+					"artifacts.druid.gg/druid-team/druid:v0.1.258",
 				)
 				findGeneratedProcedure(t, scroll.Commands["login"].Procedures, "authenticate-hytale")
 				findGeneratedProcedure(t, scroll.Commands["update"].Procedures, "install-hytale-server")
+			default:
+				t.Fatalf("released Scroll has no explicit HIG-24 progress classification: %s", path)
 			}
 		})
+	}
+}
+
+func TestPushRetargetsEmbeddedProgressImages(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is required")
+	}
+
+	tests := []struct {
+		name          string
+		environment   []string
+		expectedImage string
+	}{
+		{
+			name: "explicit preview images",
+			environment: []string{
+				"DRUID_SCROLL_RUNTIME_IMAGE=local.example/druid:test",
+				"DRUID_SCROLL_STEAMCMD_IMAGE=local.example/druid:test-steamcmd",
+			},
+			expectedImage: "local.example/druid:test",
+		},
+		{
+			name: "plain HTTP local seed",
+			environment: []string{
+				"SCROLL_REGISTRY_HOST=http://druid-gs:8088",
+				"DRUID_REGISTRY_PLAIN_HTTP=true",
+			},
+			expectedImage: "druid:local",
+		},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeDir := filepath.Join(".", fmt.Sprintf(".push-test-%d-%d", os.Getpid(), index))
+			if err := os.Mkdir(fakeDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(fakeDir) })
+			fakeDruid := filepath.Join(fakeDir, "druid")
+			script := `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" != "push" || "$2" == "category" ]]; then
+  exit 0
+fi
+source_dir="$3"
+scroll="$source_dir/scroll.yaml"
+if grep -Fq 'artifacts.druid.gg/druid-team/druid:v0.1.258' "$scroll"; then
+  echo "pinned progress image leaked into packaged Scroll: $scroll" >&2
+  exit 41
+fi
+if ! grep -Fq "$EXPECTED_PROGRESS_IMAGE" "$scroll"; then
+  echo "retargeted progress image missing from packaged Scroll: $scroll" >&2
+  exit 42
+fi
+`
+			if err := os.WriteFile(fakeDruid, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			command := exec.Command("bash", "scripts/push.sh")
+			command.Env = append(
+				os.Environ(),
+				"DRUID_BIN="+filepath.ToSlash(fakeDruid),
+				"SCROLL_PUSH_CATEGORIES=0",
+				"SCROLL_PUSH_ARTIFACTS=1",
+				"EXPECTED_PROGRESS_IMAGE="+test.expectedImage,
+			)
+			command.Env = append(command.Env, test.environment...)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("push.sh failed: %v\n%s", err, output)
+			}
+		})
+	}
+}
+
+func TestWorkflowsUseProgressCapableCLIVersion(t *testing.T) {
+	for _, path := range []string{".github/workflows/pr.yml", ".github/workflows/release.yml"} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(content), "DRUID_CLI_VERSION: v0.1.258") {
+			t.Fatalf("%s does not use the progress-capable CLI release", path)
+		}
 	}
 }
 
@@ -254,7 +343,7 @@ func requireCompatibleProgressImages(t *testing.T, scroll generatedScroll) {
 			if !generatedCommandHasPrefix(procedure.Command, "druid", "progress") {
 				continue
 			}
-			expected := "artifacts.druid.gg/druid-team/druid:stable"
+			expected := "artifacts.druid.gg/druid-team/druid:v0.1.258"
 			if len(procedure.Command) > 2 && procedure.Command[2] == "steamcmd" {
 				expected += "-steamcmd"
 			}

--- a/generate-scrolls_test.go
+++ b/generate-scrolls_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"regexp"
 	"slices"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -80,6 +83,65 @@ func TestGeneratedSharedPortsRemainConcrete(t *testing.T) {
 	}
 }
 
+func TestReleasedScrollsHaveTruthfulInstallProgress(t *testing.T) {
+	for _, path := range releasedScrollPaths(t) {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			scroll := readGeneratedScroll(t, filepath.Join(path, "scroll.yaml"))
+			commands := allGeneratedProcedureCommands(scroll)
+			for _, command := range commands {
+				joined := strings.Join(command, " ")
+				if rawDownloadCommandPattern.MatchString(joined) &&
+					!generatedCommandHasPrefix(command, "druid", "progress") {
+					t.Fatalf("raw payload download has no structured progress: %q", joined)
+				}
+			}
+			requireCompatibleProgressImages(t, scroll)
+			rejectRawDownloadScripts(t, path)
+
+			switch {
+			case strings.Contains(path, "/lgsm/"):
+				requireGeneratedCommandPrefix(t, commands, "druid", "progress", "steamcmd", "--")
+				requireGeneratedProcedureImage(
+					t,
+					scroll,
+					[]string{"sh", "install-lgsm.sh"},
+					"artifacts.druid.gg/druid-team/druid:stable-steamcmd",
+				)
+			case strings.Contains(path, "/rust/"):
+				requireGeneratedCommandPrefix(t, commands, "druid", "progress", "steamcmd", "--")
+				if strings.Contains(path, "rust-oxide") {
+					requireGeneratedCommandPrefix(t, commands, "druid", "progress", "download")
+				}
+			case strings.Contains(path, "/minecraft/"):
+				requireGeneratedCommandPrefix(t, commands, "druid", "progress", "download")
+				if strings.Contains(path, "/forge/") {
+					findGeneratedProcedure(t, scroll.Commands["install"].Procedures, "install-forge-server")
+				}
+			case strings.Contains(path, "/hytale/hytale-druid-gg"):
+				requireGeneratedCommandPrefix(t, commands, "druid", "progress", "download")
+				findGeneratedProcedure(t, scroll.Commands["install-server"].Procedures, "install-hytale-server")
+			case strings.Contains(path, "/hytale/hytale-standalone"):
+				installScript, err := os.ReadFile(filepath.Join(path, "data", "install.sh"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(string(installScript), "druid progress download") {
+					t.Fatal("Hytale standalone HSM download has no structured progress")
+				}
+				requireGeneratedProcedureImage(
+					t,
+					scroll,
+					[]string{"sh", "install.sh"},
+					"artifacts.druid.gg/druid-team/druid:stable",
+				)
+				findGeneratedProcedure(t, scroll.Commands["login"].Procedures, "authenticate-hytale")
+				findGeneratedProcedure(t, scroll.Commands["update"].Procedures, "install-hytale-server")
+			}
+		})
+	}
+}
+
 type generatedScroll struct {
 	Ports    []generatedPort             `yaml:"ports"`
 	Commands map[string]generatedCommand `yaml:"commands"`
@@ -96,6 +158,7 @@ type generatedCommand struct {
 
 type generatedProcedure struct {
 	ID            string                  `yaml:"id"`
+	Image         string                  `yaml:"image"`
 	ExpectedPorts []generatedExpectedPort `yaml:"expectedPorts"`
 	Command       []string                `yaml:"command"`
 }
@@ -135,4 +198,116 @@ func hasGeneratedExpectedPort(ports []generatedExpectedPort, name string) bool {
 		}
 	}
 	return false
+}
+
+func releasedScrollPaths(t *testing.T) []string {
+	t.Helper()
+	content, err := os.ReadFile("scripts/push.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern := regexp.MustCompile(`(?m)^\s*run druid push \S+\s+(\./scrolls/\S+)`)
+	matches := pattern.FindAllStringSubmatch(string(content), -1)
+	seen := map[string]bool{}
+	paths := make([]string, 0, len(matches))
+	for _, match := range matches {
+		path := strings.TrimPrefix(match[1], "./")
+		if !seen[path] {
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	if len(paths) == 0 {
+		t.Fatal("release catalog did not contain any Scroll paths")
+	}
+	return paths
+}
+
+func allGeneratedProcedureCommands(scroll generatedScroll) [][]string {
+	commands := make([][]string, 0)
+	for _, command := range scroll.Commands {
+		for _, procedure := range command.Procedures {
+			commands = append(commands, procedure.Command)
+		}
+	}
+	return commands
+}
+
+func requireGeneratedCommandPrefix(t *testing.T, commands [][]string, prefix ...string) {
+	t.Helper()
+	for _, command := range commands {
+		if generatedCommandHasPrefix(command, prefix...) {
+			return
+		}
+	}
+	t.Fatalf("no procedure command starts with %q", strings.Join(prefix, " "))
+}
+
+func generatedCommandHasPrefix(command []string, prefix ...string) bool {
+	return len(command) >= len(prefix) && slices.Equal(command[:len(prefix)], prefix)
+}
+
+func requireCompatibleProgressImages(t *testing.T, scroll generatedScroll) {
+	t.Helper()
+	for _, command := range scroll.Commands {
+		for _, procedure := range command.Procedures {
+			if !generatedCommandHasPrefix(procedure.Command, "druid", "progress") {
+				continue
+			}
+			expected := "artifacts.druid.gg/druid-team/druid:stable"
+			if len(procedure.Command) > 2 && procedure.Command[2] == "steamcmd" {
+				expected += "-steamcmd"
+			}
+			if procedure.Image != expected {
+				t.Fatalf("progress command %q uses incompatible image %q; want %q",
+					strings.Join(procedure.Command, " "), procedure.Image, expected)
+			}
+		}
+	}
+}
+
+func requireGeneratedProcedureImage(
+	t *testing.T,
+	scroll generatedScroll,
+	command []string,
+	expectedImage string,
+) {
+	t.Helper()
+	for _, scrollCommand := range scroll.Commands {
+		for _, procedure := range scrollCommand.Procedures {
+			if slices.Equal(procedure.Command, command) {
+				if procedure.Image != expectedImage {
+					t.Fatalf("command %q uses incompatible image %q; want %q",
+						strings.Join(command, " "), procedure.Image, expectedImage)
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("procedure command %q not found", strings.Join(command, " "))
+}
+
+var rawDownloadCommandPattern = regexp.MustCompile(`(^|[[:space:];|&])(wget|curl|steamcmd)([[:space:];|&]|$)`)
+
+func rejectRawDownloadScripts(t *testing.T, root string) {
+	t.Helper()
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Ext(path) != ".sh" {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if rawDownloadCommandPattern.Match(content) {
+			t.Fatalf("raw payload download in published script %s has no structured progress", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -13,7 +13,7 @@ SCROLL_REGISTRY_HOST="${SCROLL_REGISTRY_HOST:-artifacts.druid.gg}"
 SCROLL_REGISTRY_NAMESPACE="${SCROLL_REGISTRY_NAMESPACE:-druid-team}"
 SCROLL_REGISTRY_USER="${SCROLL_REGISTRY_USER:-}"
 SCROLL_REGISTRY_PASSWORD="${SCROLL_REGISTRY_PASSWORD:-}"
-DRUID_CLI_VERSION="${DRUID_CLI_VERSION:-v0.1.257}"
+DRUID_CLI_VERSION="${DRUID_CLI_VERSION:-v0.1.258}"
 SCROLL_PUSH_CATEGORIES="${SCROLL_PUSH_CATEGORIES:-1}"
 SCROLL_PUSH_ARTIFACTS="${SCROLL_PUSH_ARTIFACTS:-1}"
 
@@ -27,8 +27,16 @@ registry_host="${registry_host%%/*}"
 registry_prefix="${registry_host}/${SCROLL_REGISTRY_NAMESPACE}"
 runtime_namespace="${SCROLL_REGISTRY_RUNTIME_NAMESPACE:-${SCROLL_REGISTRY_NAMESPACE}}"
 runtime_prefix="${registry_host}/${runtime_namespace}"
-runtime_image="${DRUID_SCROLL_RUNTIME_IMAGE:-${runtime_prefix}/druid:${DRUID_CLI_VERSION}}"
-steamcmd_image="${DRUID_SCROLL_STEAMCMD_IMAGE:-${runtime_image}-steamcmd}"
+if [[ -n "${DRUID_SCROLL_RUNTIME_IMAGE:-}" ]]; then
+  runtime_image="$DRUID_SCROLL_RUNTIME_IMAGE"
+elif [[ "${DRUID_REGISTRY_PLAIN_HTTP:-false}" == "true" ]]; then
+  runtime_image="${DRUID_K8S_PULL_IMAGE:-druid:local}"
+else
+  runtime_image="${runtime_prefix}/druid:${DRUID_CLI_VERSION}"
+fi
+steamcmd_image="${DRUID_SCROLL_STEAMCMD_IMAGE:-${DRUID_K8S_STEAMCMD_IMAGE:-${runtime_image}-steamcmd}}"
+pinned_progress_image="artifacts.druid.gg/druid-team/druid:v0.1.258"
+pinned_steamcmd_progress_image="${pinned_progress_image}-steamcmd"
 
 login_if_configured() {
   if [[ "$SCROLL_PUSH_DRY_RUN" = "1" ]]; then
@@ -41,6 +49,7 @@ login_if_configured() {
 
 run() {
   local command="$*"
+  local temporary_source=""
 
   # Add the optional suffix only to artifact tags. Category pushes are metadata
   # for the stable repository and do not get PR suffixes.
@@ -62,13 +71,47 @@ run() {
   # local Harbor, staging, or PR namespaces without changing every push line.
   command="${command//artifacts.druid.gg\/druid-team\/druid:v0.1.257-steamcmd/$steamcmd_image}"
   command="${command//artifacts.druid.gg\/druid-team\/druid:v0.1.257/$runtime_image}"
+  command="${command//$pinned_steamcmd_progress_image/$steamcmd_image}"
+  command="${command//$pinned_progress_image/$runtime_image}"
   command="${command//artifacts.druid.gg\/druid-team/$registry_prefix}"
+
+  # A Scroll may embed a progress-capable procedure image in scroll.yaml.
+  # Package a temporary, retargeted copy so local and preview artifacts do not
+  # accidentally depend on the production registry or a mutable tag.
+  if [[ "$SCROLL_PUSH_DRY_RUN" != "1" && "$command" == druid\ push\ * && "$command" != druid\ push\ category\ * ]]; then
+    local rest ref source_dir escaped_runtime_image escaped_steamcmd_image
+    rest="${command#druid push }"
+    ref="${rest%% *}"
+    rest="${rest#"$ref" }"
+    source_dir="${rest%% *}"
+    if [[ -f "$source_dir/scroll.yaml" ]]; then
+      temporary_source="$(mktemp -d "${TMPDIR:-/tmp}/druid-scroll-push.XXXXXX")"
+      cp -a "$source_dir/." "$temporary_source/"
+      escaped_runtime_image="${runtime_image//\\/\\\\}"
+      escaped_runtime_image="${escaped_runtime_image//&/\\&}"
+      escaped_runtime_image="${escaped_runtime_image//|/\\|}"
+      escaped_steamcmd_image="${steamcmd_image//\\/\\\\}"
+      escaped_steamcmd_image="${escaped_steamcmd_image//&/\\&}"
+      escaped_steamcmd_image="${escaped_steamcmd_image//|/\\|}"
+      sed -i \
+        -e "s|$pinned_steamcmd_progress_image|$escaped_steamcmd_image|g" \
+        -e "s|$pinned_progress_image|$escaped_runtime_image|g" \
+        "$temporary_source/scroll.yaml"
+      command="${command/"$source_dir"/"$temporary_source"}"
+    fi
+  fi
+
   command="${command/#druid /"$DRUID_BIN" }"
   echo "$command"
   if [[ "$SCROLL_PUSH_DRY_RUN" = "1" ]]; then
     return 0
   fi
-  eval "$command"
+  local status=0
+  eval "$command" || status=$?
+  if [[ -n "$temporary_source" ]]; then
+    rm -rf -- "$temporary_source"
+  fi
+  return "$status"
 }
 
 push_release_categories() {

--- a/scrolls/hytale/hytale-druid-gg/scroll.yaml
+++ b/scrolls/hytale/hytale-druid-gg/scroll.yaml
@@ -10,25 +10,33 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
+    - id: download-hytale-updater
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - update-server.sh
+      - --label
+      - Downloading Hytale updater
       - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-update-hytale-server.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable
+    - id: download-hytale-launcher
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - start-server.sh
+      - --label
+      - Downloading Hytale launcher
       - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-start-hytale-server.sh
     - image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
@@ -44,7 +52,8 @@ commands:
     needs:
     - install
     procedures:
-    - image: eclipse-temurin:25-jre
+    - id: install-hytale-server
+      image: eclipse-temurin:25-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/hytale/hytale-druid-gg/scroll.yaml
+++ b/scrolls/hytale/hytale-druid-gg/scroll.yaml
@@ -11,7 +11,7 @@ commands:
     run: once
     procedures:
     - id: download-hytale-updater
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -25,7 +25,7 @@ commands:
       - Downloading Hytale updater
       - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-update-hytale-server.sh
     - id: download-hytale-launcher
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -38,7 +38,7 @@ commands:
       - --label
       - Downloading Hytale launcher
       - https://github.com/highcard-dev/hsm/releases/latest/download/gsp-start-hytale-server.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/hytale/hytale-standalone/data/install.sh
+++ b/scrolls/hytale/hytale-standalone/data/install.sh
@@ -25,6 +25,6 @@ else
 fi
 
 echo "Downloading hsm ${VERSION} for ${OS}/${ARCH}..."
-wget -q -O hsm "$URL"
+druid progress download --output hsm --label "Downloading Hytale server manager" "$URL"
 chmod +x hsm
 echo "Done"

--- a/scrolls/hytale/hytale-standalone/scroll.yaml
+++ b/scrolls/hytale/hytale-standalone/scroll.yaml
@@ -22,7 +22,8 @@ commands:
     needs:
     - install-hsm
     procedures:
-    - image: eclipse-temurin:25-jre
+    - id: authenticate-hytale
+      image: eclipse-temurin:25-jre
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -33,7 +34,8 @@ commands:
     needs:
     - login
     procedures:
-    - image: eclipse-temurin:25-jre
+    - id: install-hytale-server
+      image: eclipse-temurin:25-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/hytale/hytale-standalone/scroll.yaml
+++ b/scrolls/hytale/hytale-standalone/scroll.yaml
@@ -10,7 +10,7 @@ commands:
   install-hsm:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/.build/data/install-lgsm.sh
+++ b/scrolls/lgsm/.build/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -142,11 +142,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: {{ .SteamImage }}
+      image: {{ .ProgressSteamImage }}
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./{{ .Version }}
       - update
 {{- if .Vars.runtime_config_script }}
@@ -224,7 +228,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: {{ .SteamImage }}
+    - image: {{ .ProgressSteamImage }}
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -245,11 +249,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: {{ .SteamImage }}
+    - image: {{ .ProgressSteamImage }}
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./{{ .Version }}
       - auto-install
 {{- if eq .Vars.postinstall "enabled" }}

--- a/scrolls/lgsm/arkserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/arkserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -112,6 +112,10 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - "--"
       - ./arkserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -205,6 +209,10 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - "--"
       - ./arkserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -107,7 +107,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -115,7 +115,7 @@ commands:
       - druid
       - progress
       - steamcmd
-      - "--"
+      - --
       - ./arkserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -183,7 +183,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -204,7 +204,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -212,7 +212,7 @@ commands:
       - druid
       - progress
       - steamcmd
-      - "--"
+      - --
       - ./arkserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -107,7 +107,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -183,7 +183,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -204,7 +204,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/cs2server/data/install-lgsm.sh
+++ b/scrolls/lgsm/cs2server/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -111,7 +111,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -165,7 +165,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -186,7 +186,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -111,11 +111,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./cs2server
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -161,7 +165,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -182,11 +186,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./cs2server
       - auto-install
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd

--- a/scrolls/lgsm/csgoserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/csgoserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -63,7 +63,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -117,7 +117,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -138,7 +138,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -63,11 +63,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./csgoserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -113,7 +117,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -134,11 +138,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./csgoserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/dayzserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/dayzserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -52,11 +52,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./dayzserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -102,7 +106,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -123,11 +127,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./dayzserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -106,7 +106,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -127,7 +127,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/gmodserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/gmodserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -65,11 +65,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./gmodserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -115,7 +119,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -136,11 +140,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./gmodserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -65,7 +65,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -119,7 +119,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -140,7 +140,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pwserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/pwserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -49,7 +49,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -103,7 +103,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -124,7 +124,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -49,11 +49,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./pwserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -99,7 +103,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -120,11 +124,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./pwserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/pzserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/pzserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -92,11 +92,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./pzserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -143,7 +147,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -164,11 +168,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./pzserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -92,7 +92,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -147,7 +147,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -168,7 +168,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/sdtdserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/sdtdserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -63,11 +63,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./sdtdserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -113,7 +117,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -134,11 +138,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./sdtdserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -63,7 +63,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -117,7 +117,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -138,7 +138,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/untserver/data/install-lgsm.sh
+++ b/scrolls/lgsm/untserver/data/install-lgsm.sh
@@ -1,7 +1,8 @@
 set -e
 
 rm -rf LinuxGSM-master
-wget https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master -O lgsm.tar.gz
+druid progress download --output lgsm.tar.gz --label "Downloading LinuxGSM" \
+  https://codeload.github.com/GameServerManagers/LinuxGSM/tar.gz/refs/heads/master
 tar -xzf lgsm.tar.gz
 
 mkdir -p lgsm

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -55,7 +55,7 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -109,7 +109,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -130,7 +130,7 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -55,11 +55,15 @@ commands:
     - install
     procedures:
     - ignore_failure: true
-      image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+      image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./untserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -105,7 +109,7 @@ commands:
       command:
       - echo
       - Installing LGSM...
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -126,11 +130,15 @@ commands:
       command:
       - sh
       - patch-lgsm-permissions.sh
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - ./untserver
       - auto-install
 serve: console

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -54,7 +54,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/cuberite/latest/scroll.yaml
+++ b/scrolls/minecraft/cuberite/latest/scroll.yaml
@@ -53,15 +53,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - Cuberite.tar.gz
+      - --label
+      - Downloading Cuberite server files
       - https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256
       mounts:

--- a/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/forge/.build/scroll.yaml.tmpl
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: {{ .ProgressImage }}
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-{{ .Version }}.jar
-    - image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
+    - id: install-forge-server
+      image: eclipse-temurin:{{ or .Vars.jdkVersion "21" }}-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.17.1/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.17.1.jar
-    - image: eclipse-temurin:16-jre
+    - id: install-forge-server
+      image: eclipse-temurin:16-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.1/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.1.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18.2/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.2.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.18.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.18/scroll.yaml
+++ b/scrolls/minecraft/forge/1.18/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.1/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.1.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.2/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.2.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.3/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.3.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19.4/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.4.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.19/scroll.yaml
+++ b/scrolls/minecraft/forge/1.19/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.19.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.1/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.1.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.2/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.2.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.3.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.3/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.4/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.4.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20.6/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.6.jar
-    - image: eclipse-temurin:17-jre
+    - id: install-forge-server
+      image: eclipse-temurin:17-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.20.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.20/scroll.yaml
+++ b/scrolls/minecraft/forge/1.20/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.1/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.1.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.3/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.3.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.4.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.4/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.5/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.5.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.6/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.6.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -59,17 +59,22 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-forge-installer
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - forge-installer.jar
+      - --label
+      - Downloading Forge installer
       - http://192.168.100.200:9000/snapshot-cache/minecraft/forge/forge-1.21.7.jar
-    - image: eclipse-temurin:21-jre
+    - id: install-forge-server
+      image: eclipse-temurin:21-jre
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/forge/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/forge/1.21.7/scroll.yaml
@@ -60,7 +60,7 @@ commands:
     run: once
     procedures:
     - id: download-forge-installer
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-spigot/.build/scroll.yaml.tmpl
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: {{ .ProgressImage }}
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-{{ .Version }}.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.17.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.17/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.17.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18.2/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.2.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.18/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.18.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.2/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.2.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.3/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.3.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19.4/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.4.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.19/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.19.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.2/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.2.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.4/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.4.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.20.6/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.20.6.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.3/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.3.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.4/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.4.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.5/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.5.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.6/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.6.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
+++ b/scrolls/minecraft/minecraft-spigot/1.21.8/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - spigot.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/spigot/spigot-1.21.8.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/minecraft-vanilla/.build/scroll.yaml.tmpl
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: {{ .ProgressImage }}
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - {{ .Vars.jarUrl }}
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar {{ .Vars.jarUrl }}
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17.1/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.17/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/125e5adf40c659fd3bce3e66e67a16bb49ecc1b9/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.1/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18.2/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/3cf24a8694aca6267883b17d934efacc5e44440d/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.18/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.1/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.2/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/c9df48efed58511cdd0213c56b9013a7b5c9ac1f/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.3/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8f3112a1049751cc472ec13e397eade5336ca7ae/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19.4/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/e00c4052dac1d59a1188b2aa9d5a87113aaf1122/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.19/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/84194a2f286ef7c14ed7ce0090dba59902951553/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.1/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.2/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/5b868151bd02b41319f54c8d4061b8cae84e665c/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.4/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://launcher.mojang.com/v1/objects/145ff0858209bcfc164859ba735d4199aafa1eea/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.20.6/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.1/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/45810d238246d90e811d896f87b14695b7fb6839/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.3/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.4/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/e6ec2f64e6080b9b5d9b471b291c33cc7f509733/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.5/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.6/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/6e64dcabba3c01a7271b4fa6bd898483b794c59b/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -52,6 +52,20 @@ commands:
   install:
     run: once
     procedures:
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
+      mounts:
+      - path: "/server"
+      working_dir: "/server"
+      command:
+      - druid
+      - progress
+      - download
+      - --output
+      - server.jar
+      - --label
+      - Downloading Minecraft server files
+      - https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
     - image: alpine:3.20
       mounts:
       - path: "/server"
@@ -59,10 +73,7 @@ commands:
       command:
       - sh
       - "-c"
-      - >-
-        apk add --no-cache ca-certificates wget
-        && wget -q -O server.jar https://piston-data.mojang.com/v1/objects/05e4b48fbc01f0385adb74bcff9751d34552486c/server.jar
-        && echo eula=true > eula.txt
+      - echo eula=true > eula.txt
   update:
     procedures:
     - image: alpine:3.20

--- a/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/minecraft-vanilla/1.21.7/scroll.yaml
@@ -53,7 +53,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
+++ b/scrolls/minecraft/papermc/.build/scroll.yaml.tmpl
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: {{ .ProgressImage }}
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-{{ .Version }}.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.17.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.17.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.17/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.17/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.17.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.18.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.18.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.18.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.18.2/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.18.2.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.19.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.2.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.19.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.2/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.19.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.3/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.3.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.19.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19.4/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.4.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.19/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.19/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.19.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.20.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.20.2/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.2/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.2.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.20.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.4/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.4.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.20.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.20.6/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.20.6.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.21.1/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.1/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.1.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.21.3/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.3/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.3.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.21.4/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.4/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.4.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.21.5/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.5/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.5.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.21.6/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.6/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.6.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -52,7 +52,7 @@ commands:
     run: once
     procedures:
     - id: download-server-files
-      image: artifacts.druid.gg/druid-team/druid:stable
+      image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/minecraft/papermc/1.21.7/scroll.yaml
+++ b/scrolls/minecraft/papermc/1.21.7/scroll.yaml
@@ -51,15 +51,19 @@ commands:
   install:
     run: once
     procedures:
-    - image: alpine:3.20
+    - id: download-server-files
+      image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-q"
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - paper.jar
+      - --label
+      - Downloading Minecraft server files
       - http://192.168.100.200:9000/snapshot-cache/minecraft/papermc/paper-1.21.7.jar
     - image: alpine:3.20
       mounts:

--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -72,11 +72,15 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - steamcmd
       - "+force_install_dir"
       - "/server"
@@ -85,14 +89,18 @@ commands:
       - "+app_update"
       - '258550'
       - "+quit"
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
-      - wget
-      - "-O"
+      - druid
+      - progress
+      - download
+      - --output
       - oxide.zip
+      - --label
+      - Downloading Oxide server files
       - https://umod.org/games/rust/download/develop
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
       mounts:

--- a/scrolls/rust/rust-oxide/latest/scroll.yaml
+++ b/scrolls/rust/rust-oxide/latest/scroll.yaml
@@ -72,7 +72,7 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
@@ -89,7 +89,7 @@ commands:
       - "+app_update"
       - '258550'
       - "+quit"
-    - image: artifacts.druid.gg/druid-team/druid:stable
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258
       mounts:
       - path: "/server"
       working_dir: "/server"

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -72,11 +72,15 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"
       command:
+      - druid
+      - progress
+      - steamcmd
+      - --
       - steamcmd
       - "+force_install_dir"
       - "/server"

--- a/scrolls/rust/rust-vanilla/latest/scroll.yaml
+++ b/scrolls/rust/rust-vanilla/latest/scroll.yaml
@@ -72,7 +72,7 @@ commands:
   install:
     run: once
     procedures:
-    - image: artifacts.druid.gg/druid-team/druid:stable-steamcmd
+    - image: artifacts.druid.gg/druid-team/druid:v0.1.258-steamcmd
       mounts:
       - path: "/server"
       working_dir: "/server"


### PR DESCRIPTION
## Summary

- instrument every published SteamCMD-based LGSM and Rust Scroll through the shared `druid progress steamcmd` adapter
- route measurable Minecraft, Cuberite, Oxide, and Hytale HTTP payloads through the central `druid progress download` producer
- give Forge and non-measurable Hytale work stable, truthful opaque installation phases instead of fake percentages
- pin progress-capable procedure images to `v0.1.258` instead of mutable `stable` tags
- retarget embedded procedure images when publishing local or preview artifacts
- make plain-HTTP local seeding use `druid:local` and `druid:local-steamcmd`
- enforce catalog-wide classification so a newly published Scroll cannot silently bypass the progress contract

## Dependency and merge order

This consumes the producers added by highcard-dev/druid-cli#97.

1. release druid-cli#97 as `v0.1.258`
2. merge this PR
3. merge highcard-dev/monorepo#318

## Validation

- `go test -count=1 ./...`
- `bash -n scripts/push.sh`
- fake publication verifies embedded images for explicit preview targets and the plain-HTTP local seed path
- catalog regression validates every released Scroll family
- `make -n k3d-build-pull-image` confirms both required local images
- `git diff --check`

## End-to-end evidence

- Cuberite exercised the real HTTP producer and reached `Active`
- Project Zomboid exercised the real SteamCMD producer and completed installation
- a realistic sparse SteamCMD trace verified speed, gated ETA, stall handling, and recovery without another multi-gigabyte game download

Backend and SPA PRs:

- https://github.com/highcard-dev/druid-cli/pull/97
- https://github.com/highcard-dev/monorepo/pull/318
