### PR TITLE
fix(lgsm): stream SteamCMD progress without buffering

### DIFF
--- a/generate-scrolls_test.go
+++ b/generate-scrolls_test.go
@@ -80,6 +80,21 @@ func TestGeneratedSharedPortsRemainConcrete(t *testing.T) {
 	}
 }
 
+func TestGeneratedLGSMDownloadCommandsAreLineBuffered(t *testing.T) {
+	scroll := readGeneratedScroll(t, "scrolls/lgsm/arkserver/scroll.yaml")
+
+	update := scroll.Commands["start"].Procedures[0].Command
+	if !slices.Equal(update, []string{"stdbuf", "-oL", "./arkserver", "update"}) {
+		t.Fatalf("ARK update command = %#v", update)
+	}
+
+	installProcedures := scroll.Commands["install"].Procedures
+	autoInstall := installProcedures[len(installProcedures)-1].Command
+	if !slices.Equal(autoInstall, []string{"stdbuf", "-oL", "./arkserver", "auto-install"}) {
+		t.Fatalf("ARK auto-install command = %#v", autoInstall)
+	}
+}
+
 type generatedScroll struct {
 	Ports    []generatedPort             `yaml:"ports"`
 	Commands map[string]generatedCommand `yaml:"commands"`

--- a/scrolls/lgsm/.build/scroll.yaml.tmpl
+++ b/scrolls/lgsm/.build/scroll.yaml.tmpl
@@ -147,6 +147,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./{{ .Version }}
       - update
 {{- if .Vars.runtime_config_script }}
@@ -250,6 +252,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./{{ .Version }}
       - auto-install
 {{- if eq .Vars.postinstall "enabled" }}

--- a/scrolls/lgsm/arkserver/scroll.yaml
+++ b/scrolls/lgsm/arkserver/scroll.yaml
@@ -112,6 +112,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./arkserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -205,6 +207,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./arkserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/cs2server/scroll.yaml
+++ b/scrolls/lgsm/cs2server/scroll.yaml
@@ -116,6 +116,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./cs2server
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -187,6 +189,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./cs2server
       - auto-install
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd

--- a/scrolls/lgsm/csgoserver/scroll.yaml
+++ b/scrolls/lgsm/csgoserver/scroll.yaml
@@ -68,6 +68,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./csgoserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -139,6 +141,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./csgoserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/dayzserver/scroll.yaml
+++ b/scrolls/lgsm/dayzserver/scroll.yaml
@@ -57,6 +57,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./dayzserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -128,6 +130,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./dayzserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/gmodserver/scroll.yaml
+++ b/scrolls/lgsm/gmodserver/scroll.yaml
@@ -70,6 +70,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./gmodserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -141,6 +143,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./gmodserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/pwserver/scroll.yaml
+++ b/scrolls/lgsm/pwserver/scroll.yaml
@@ -54,6 +54,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./pwserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -125,6 +127,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./pwserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/pzserver/scroll.yaml
+++ b/scrolls/lgsm/pzserver/scroll.yaml
@@ -97,6 +97,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./pzserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -169,6 +171,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./pzserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/sdtdserver/scroll.yaml
+++ b/scrolls/lgsm/sdtdserver/scroll.yaml
@@ -68,6 +68,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./sdtdserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -139,6 +141,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./sdtdserver
       - auto-install
 serve: console

--- a/scrolls/lgsm/untserver/scroll.yaml
+++ b/scrolls/lgsm/untserver/scroll.yaml
@@ -60,6 +60,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./untserver
       - update
     - image: artifacts.druid.gg/druid-team/druid:v0.1.256-steamcmd
@@ -131,6 +133,8 @@ commands:
       - path: "/server"
       working_dir: "/server"
       command:
+      - stdbuf
+      - -oL
       - ./untserver
       - auto-install
 serve: console


### PR DESCRIPTION
## Summary

- line-buffer LinuxGSM update and auto-install output with `stdbuf -oL`
- apply the shared template change to all nine generated LinuxGSM Scrolls
- keep `SnapshotProgress` as the only progress source; no estimates or synthetic values

## Why

SteamCMD emits real progress frequently, but `uniq` buffered the pipe output. That delayed valid samples and produced the observed long pauses and large jumps. Line buffering forwards each existing progress line immediately without adding a PTY or another progress mechanism.

## Verification

- `go test -count=1 ./...`
- `./scripts/validate_all_scrolls.sh`
- `git diff --check`

Related: highcard-dev/druid-cli#97 and highcard-dev/monorepo#318.